### PR TITLE
Update the signatures implementation, prepare for wiggle

### DIFF
--- a/proposals/poc/implementation/Cargo.toml
+++ b/proposals/poc/implementation/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-lazy_static = "1.4"
 parking_lot = "0.10"
 ring = "0.16"
 thiserror = "1.0"

--- a/proposals/poc/implementation/src/array_output.rs
+++ b/proposals/poc/implementation/src/array_output.rs
@@ -8,6 +8,10 @@ use super::{HandleManagers, WasiCryptoCtx};
 pub struct ArrayOutput(Cursor<Vec<u8>>);
 
 impl ArrayOutput {
+    fn len(&self) -> usize {
+        self.0.get_ref().len()
+    }
+
     fn pull(&self, buf: &mut [u8]) -> Result<usize, Error> {
         let data = self.0.get_ref();
         let data_len = data.len();
@@ -35,14 +39,19 @@ impl Read for ArrayOutput {
 }
 
 impl WasiCryptoCtx {
+    pub fn array_output_len(&self, array_output_handle: Handle) -> Result<usize, Error> {
+        let array_output = self.handles.array_output.get(array_output_handle)?;
+        Ok(array_output.len())
+    }
+
     pub fn array_output_pull(
         &self,
         array_output_handle: Handle,
         buf: &mut [u8],
     ) -> Result<usize, Error> {
         let array_output = self.handles.array_output.get(array_output_handle)?;
-        let size = array_output.pull(buf)?;
+        let len = array_output.pull(buf)?;
         self.handles.array_output.close(array_output_handle)?;
-        Ok(size)
+        Ok(len)
     }
 }

--- a/proposals/poc/implementation/src/array_output.rs
+++ b/proposals/poc/implementation/src/array_output.rs
@@ -1,0 +1,48 @@
+use std::io::{Cursor, Read};
+
+use super::error::*;
+use super::handles::*;
+use super::{HandleManagers, WasiCryptoCtx};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArrayOutput(Cursor<Vec<u8>>);
+
+impl ArrayOutput {
+    fn pull(&self, buf: &mut [u8]) -> Result<usize, Error> {
+        let data = self.0.get_ref();
+        let data_len = data.len();
+        let buf_len = buf.len();
+        ensure!(buf_len >= data_len, CryptoError::Overflow);
+        buf.copy_from_slice(data);
+        Ok(buf_len)
+    }
+
+    pub fn new(data: Vec<u8>) -> Self {
+        ArrayOutput(Cursor::new(data))
+    }
+
+    pub fn register(handles: &HandleManagers, data: Vec<u8>) -> Result<Handle, Error> {
+        let array_output = ArrayOutput::new(data);
+        let handle = handles.array_output.register(array_output)?;
+        Ok(handle)
+    }
+}
+
+impl Read for ArrayOutput {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
+        self.0.read(buf)
+    }
+}
+
+impl WasiCryptoCtx {
+    pub fn array_output_pull(
+        &self,
+        array_output_handle: Handle,
+        buf: &mut [u8],
+    ) -> Result<usize, Error> {
+        let array_output = self.handles.array_output.get(array_output_handle)?;
+        let size = array_output.pull(buf)?;
+        self.handles.array_output.close(array_output_handle)?;
+        Ok(size)
+    }
+}

--- a/proposals/poc/implementation/src/ecdsa.rs
+++ b/proposals/poc/implementation/src/ecdsa.rs
@@ -7,7 +7,7 @@ use super::error::*;
 use super::handles::*;
 use super::signature::*;
 use super::signature_keypair::*;
-use super::WASI_CRYPTO_CTX;
+use super::HandleManagers;
 
 #[derive(Clone, Copy, Debug)]
 pub struct ECDSASignatureOp {
@@ -88,22 +88,27 @@ impl ECDSASignatureKeyPairBuilder {
         ECDSASignatureKeyPairBuilder { alg }
     }
 
-    pub fn generate(&self) -> Result<Handle, Error> {
+    pub fn generate(&self, handles: &HandleManagers) -> Result<Handle, Error> {
         let kp = ECDSASignatureKeyPair::generate(self.alg)?;
-        let handle = WASI_CRYPTO_CTX
-            .signature_keypair_manager
+        let handle = handles
+            .signature_keypair
             .register(SignatureKeyPair::ECDSA(kp))?;
         Ok(handle)
     }
 
-    pub fn import(&self, encoded: &[u8], encoding: KeyPairEncoding) -> Result<Handle, Error> {
+    pub fn import(
+        &self,
+        handles: &HandleManagers,
+        encoded: &[u8],
+        encoding: KeyPairEncoding,
+    ) -> Result<Handle, Error> {
         match encoding {
             KeyPairEncoding::PKCS8 => {}
             _ => bail!(CryptoError::UnsupportedEncoding),
         };
         let kp = ECDSASignatureKeyPair::from_pkcs8(self.alg, encoded)?;
-        let handle = WASI_CRYPTO_CTX
-            .signature_keypair_manager
+        let handle = handles
+            .signature_keypair
             .register(SignatureKeyPair::ECDSA(kp))?;
         Ok(handle)
     }

--- a/proposals/poc/implementation/src/eddsa.rs
+++ b/proposals/poc/implementation/src/eddsa.rs
@@ -7,7 +7,7 @@ use super::error::*;
 use super::handles::*;
 use super::signature::*;
 use super::signature_keypair::*;
-use super::WASI_CRYPTO_CTX;
+use super::HandleManagers;
 
 #[derive(Clone, Copy, Debug)]
 pub struct EdDSASignatureOp {
@@ -71,22 +71,27 @@ impl EdDSASignatureKeyPairBuilder {
         EdDSASignatureKeyPairBuilder { alg }
     }
 
-    pub fn generate(&self) -> Result<Handle, Error> {
+    pub fn generate(&self, handles: &HandleManagers) -> Result<Handle, Error> {
         let kp = EdDSASignatureKeyPair::generate(self.alg)?;
-        let handle = WASI_CRYPTO_CTX
-            .signature_keypair_manager
+        let handle = handles
+            .signature_keypair
             .register(SignatureKeyPair::EdDSA(kp))?;
         Ok(handle)
     }
 
-    pub fn import(&self, encoded: &[u8], encoding: KeyPairEncoding) -> Result<Handle, Error> {
+    pub fn import(
+        &self,
+        handles: &HandleManagers,
+        encoded: &[u8],
+        encoding: KeyPairEncoding,
+    ) -> Result<Handle, Error> {
         match encoding {
             KeyPairEncoding::PKCS8 => {}
             _ => bail!(CryptoError::UnsupportedEncoding),
         };
         let kp = EdDSASignatureKeyPair::from_pkcs8(self.alg, encoded)?;
-        let handle = WASI_CRYPTO_CTX
-            .signature_keypair_manager
+        let handle = handles
+            .signature_keypair
             .register(SignatureKeyPair::EdDSA(kp))?;
         Ok(handle)
     }

--- a/proposals/poc/implementation/src/error.rs
+++ b/proposals/poc/implementation/src/error.rs
@@ -2,8 +2,12 @@ pub use anyhow::{bail, ensure, Error};
 
 #[derive(thiserror::Error, Debug)]
 pub enum CryptoError {
-    #[error("Unsupported operation")]
-    UnsupportedOperation,
+    #[error("Not implemented")]
+    NotImplemented,
+    #[error("Unsupported feature")]
+    UnsupportedFeature,
+    #[error("Prohibited by local policy")]
+    ProhibitedOperation,
     #[error("Unsupported encoding")]
     UnsupportedEncoding,
     #[error("Unsupported algorithm")]
@@ -34,25 +38,29 @@ pub enum CryptoError {
 #[repr(u16)]
 pub enum WasiCryptoError {
     Success = 0,
-    UnsupportedEncoding = 1,
-    UnsupportedAlgorithm = 2,
-    UnsupportedOperation = 3,
-    InvalidKey = 4,
-    VerificationFailed = 5,
-    RNGError = 6,
-    AlgorithmFailure = 7,
-    InvalidSignature = 8,
-    Closed = 9,
-    InvalidHandle = 10,
-    Overflow = 11,
-    InternalError = 12,
-    TooManyHandles = 13,
+    NotImplemented = 1,
+    UnsupportedFeature = 2,
+    ProhibitedOperation = 3,
+    UnsupportedEncoding = 4,
+    UnsupportedAlgorithm = 5,
+    InvalidKey = 6,
+    VerificationFailed = 7,
+    RNGError = 8,
+    AlgorithmFailure = 9,
+    InvalidSignature = 10,
+    Closed = 11,
+    InvalidHandle = 12,
+    Overflow = 13,
+    InternalError = 14,
+    TooManyHandles = 15,
 }
 
 impl CryptoError {
     pub fn as_raw_errno(&self) -> WasiCryptoError {
         match self {
-            CryptoError::UnsupportedOperation => WasiCryptoError::UnsupportedOperation,
+            CryptoError::NotImplemented => WasiCryptoError::NotImplemented,
+            CryptoError::UnsupportedFeature => WasiCryptoError::UnsupportedFeature,
+            CryptoError::ProhibitedOperation => WasiCryptoError::ProhibitedOperation,
             CryptoError::UnsupportedEncoding => WasiCryptoError::UnsupportedEncoding,
             CryptoError::UnsupportedAlgorithm => WasiCryptoError::UnsupportedAlgorithm,
             CryptoError::InvalidKey => WasiCryptoError::InvalidKey,

--- a/proposals/poc/implementation/src/error.rs
+++ b/proposals/poc/implementation/src/error.rs
@@ -24,6 +24,10 @@ pub enum CryptoError {
     InvalidHandle,
     #[error("Overflow")]
     Overflow,
+    #[error("Internal error")]
+    InternalError,
+    #[error("Too many open handles")]
+    TooManyHandles,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -41,6 +45,8 @@ pub enum WasiCryptoError {
     Closed = 9,
     InvalidHandle = 10,
     Overflow = 11,
+    InternalError = 12,
+    TooManyHandles = 13,
 }
 
 impl CryptoError {
@@ -57,6 +63,8 @@ impl CryptoError {
             CryptoError::Closed => WasiCryptoError::Closed,
             CryptoError::InvalidHandle => WasiCryptoError::InvalidHandle,
             CryptoError::Overflow => WasiCryptoError::Overflow,
+            CryptoError::InternalError => WasiCryptoError::InternalError,
+            CryptoError::TooManyHandles => WasiCryptoError::TooManyHandles,
         }
     }
 }

--- a/proposals/poc/implementation/src/handles.rs
+++ b/proposals/poc/implementation/src/handles.rs
@@ -59,11 +59,14 @@ impl<HandleType: Clone + Sync> HandlesManagerInner<HandleType> {
             if !self.map.contains_key(&handle) {
                 break;
             }
-            ensure!(handle != self.last_handle, "No more handles");
+            ensure!(handle != self.last_handle, CryptoError::TooManyHandles);
             handle = self.next_handle(self.last_handle);
         }
         self.last_handle = handle;
-        ensure!(self.map.insert(handle, op).is_none(), "Collision");
+        ensure!(
+            self.map.insert(handle, op).is_none(),
+            CryptoError::InternalError
+        );
         Ok(handle)
     }
 

--- a/proposals/poc/implementation/src/lib.rs
+++ b/proposals/poc/implementation/src/lib.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate lazy_static;
-
+mod array_output;
 mod ecdsa;
 mod eddsa;
 mod error;
@@ -11,6 +9,7 @@ mod signature_keypair;
 mod signature_op;
 mod signature_publickey;
 
+use array_output::*;
 use handles::*;
 use signature::*;
 use signature_keypair::*;
@@ -23,69 +22,62 @@ pub use signature::SignatureEncoding;
 pub use signature_keypair::{KeyPairEncoding, Version};
 pub use signature_publickey::PublicKeyEncoding;
 
-pub use signature::{
-    signature_close, signature_export, signature_import, signature_state_close,
-    signature_state_open, signature_state_sign, signature_state_update,
-    signature_verification_state_close, signature_verification_state_open,
-    signature_verification_state_update, signature_verification_state_verify,
-};
-
-pub use signature_keypair::{
-    signature_keypair_builder_close, signature_keypair_builder_open, signature_keypair_close,
-    signature_keypair_export, signature_keypair_from_id, signature_keypair_generate,
-    signature_keypair_id, signature_keypair_import, signature_keypair_invalidate,
-    signature_keypair_publickey,
-};
-
-pub use signature_op::{signature_op_close, signature_op_open};
-
-pub use signature_publickey::{
-    signature_publickey_close, signature_publickey_export, signature_publickey_import,
-    signature_publickey_verify,
-};
-
-pub struct WasiCryptoCtx {
-    pub signature_op_manager: HandlesManager<SignatureOp>,
-    pub signature_keypair_builder_manager: HandlesManager<SignatureKeyPairBuilder>,
-    pub signature_keypair_manager: HandlesManager<SignatureKeyPair>,
-    pub signature_state_manager: HandlesManager<ExclusiveSignatureState>,
-    pub signature_manager: HandlesManager<Signature>,
-    pub signature_publickey_manager: HandlesManager<SignaturePublicKey>,
-    pub signature_verification_state_manager: HandlesManager<ExclusiveSignatureVerificationState>,
+pub struct HandleManagers {
+    pub signature_op: HandlesManager<SignatureOp>,
+    pub signature_keypair_builder: HandlesManager<SignatureKeyPairBuilder>,
+    pub signature_keypair: HandlesManager<SignatureKeyPair>,
+    pub signature_state: HandlesManager<ExclusiveSignatureState>,
+    pub signature: HandlesManager<Signature>,
+    pub signature_publickey: HandlesManager<SignaturePublicKey>,
+    pub signature_verification_state: HandlesManager<ExclusiveSignatureVerificationState>,
+    pub array_output: HandlesManager<ArrayOutput>,
 }
 
-// These maps should be stored in a WASI context
-lazy_static! {
-    static ref WASI_CRYPTO_CTX: WasiCryptoCtx = WasiCryptoCtx {
-        signature_op_manager: HandlesManager::new(0x00),
-        signature_keypair_builder_manager: HandlesManager::new(0x01),
-        signature_keypair_manager: HandlesManager::new(0x02),
-        signature_state_manager: HandlesManager::new(0x03),
-        signature_manager: HandlesManager::new(0x04),
-        signature_publickey_manager: HandlesManager::new(0x05),
-        signature_verification_state_manager: HandlesManager::new(0x06),
-    };
+pub struct WasiCryptoCtx {
+    pub(crate) handles: HandleManagers,
+}
+
+impl WasiCryptoCtx {
+    pub fn new() -> Self {
+        WasiCryptoCtx {
+            handles: HandleManagers {
+                array_output: HandlesManager::new(0x00),
+                signature_op: HandlesManager::new(0x01),
+                signature_keypair_builder: HandlesManager::new(0x02),
+                signature_keypair: HandlesManager::new(0x03),
+                signature_state: HandlesManager::new(0x04),
+                signature: HandlesManager::new(0x05),
+                signature_publickey: HandlesManager::new(0x06),
+                signature_verification_state: HandlesManager::new(0x07),
+            },
+        }
+    }
 }
 
 #[test]
 fn test_signatures() {
-    let op_handle = signature_op_open("ECDSA_P256_SHA256").unwrap();
-    let kp_builder_handle = signature_keypair_builder_open(op_handle).unwrap();
-    let kp_handle = signature_keypair_generate(kp_builder_handle).unwrap();
-    let state_handle = signature_state_open(kp_handle).unwrap();
-    signature_state_update(state_handle, b"test").unwrap();
-    let signature_handle = signature_state_sign(state_handle).unwrap();
+    let ctx = WasiCryptoCtx::new();
+    let op_handle = ctx.signature_op_open("ECDSA_P256_SHA256").unwrap();
+    let kp_builder_handle = ctx.signature_keypair_builder_open(op_handle).unwrap();
+    let kp_handle = ctx.signature_keypair_generate(kp_builder_handle).unwrap();
+    let state_handle = ctx.signature_state_open(kp_handle).unwrap();
+    ctx.signature_state_update(state_handle, b"test").unwrap();
+    let signature_handle = ctx.signature_state_sign(state_handle).unwrap();
 
-    let pk_handle = signature_keypair_publickey(kp_handle).unwrap();
+    let pk_handle = ctx.signature_keypair_publickey(kp_handle).unwrap();
 
-    let verification_state_handle = signature_verification_state_open(pk_handle).unwrap();
-    signature_verification_state_update(verification_state_handle, b"test").unwrap();
-    signature_verification_state_verify(verification_state_handle, signature_handle).unwrap();
+    let verification_state_handle = ctx.signature_verification_state_open(pk_handle).unwrap();
+    ctx.signature_verification_state_update(verification_state_handle, b"test")
+        .unwrap();
+    ctx.signature_verification_state_verify(verification_state_handle, signature_handle)
+        .unwrap();
 
-    signature_op_close(op_handle).unwrap();
-    signature_keypair_builder_close(kp_builder_handle).unwrap();
-    signature_keypair_close(kp_handle).unwrap();
-    signature_state_close(state_handle).unwrap();
-    signature_verification_state_close(verification_state_handle).unwrap();
-    signature_close(signature_handle).unwrap();
+    ctx.signature_op_close(op_handle).unwrap();
+    ctx.signature_keypair_builder_close(kp_builder_handle)
+        .unwrap();
+    ctx.signature_keypair_close(kp_handle).unwrap();
+    ctx.signature_state_close(state_handle).unwrap();
+    ctx.signature_verification_state_close(verification_state_handle)
+        .unwrap();
+    ctx.signature_close(signature_handle).unwrap();
 }

--- a/proposals/poc/implementation/src/rsa.rs
+++ b/proposals/poc/implementation/src/rsa.rs
@@ -51,7 +51,7 @@ impl RSASignatureKeyPair {
 
     #[allow(dead_code)]
     pub fn generate(_alg: SignatureAlgorithm) -> Result<Self, Error> {
-        bail!(CryptoError::UnsupportedOperation)
+        bail!(CryptoError::NotImplemented)
     }
 
     pub fn raw_public_key(&self) -> &[u8] {
@@ -70,7 +70,7 @@ impl RSASignatureKeyPairBuilder {
     }
 
     pub fn generate(&self, _handles: &HandleManagers) -> Result<Handle, Error> {
-        bail!(CryptoError::UnsupportedOperation)
+        bail!(CryptoError::NotImplemented)
     }
 
     pub fn import(

--- a/proposals/poc/implementation/src/rsa.rs
+++ b/proposals/poc/implementation/src/rsa.rs
@@ -7,7 +7,7 @@ use super::error::*;
 use super::handles::*;
 use super::signature::*;
 use super::signature_keypair::*;
-use super::WASI_CRYPTO_CTX;
+use super::HandleManagers;
 
 #[derive(Clone, Copy, Debug)]
 pub struct RSASignatureOp {
@@ -69,18 +69,23 @@ impl RSASignatureKeyPairBuilder {
         RSASignatureKeyPairBuilder { alg }
     }
 
-    pub fn generate(&self) -> Result<Handle, Error> {
+    pub fn generate(&self, _handles: &HandleManagers) -> Result<Handle, Error> {
         bail!(CryptoError::UnsupportedOperation)
     }
 
-    pub fn import(&self, encoded: &[u8], encoding: KeyPairEncoding) -> Result<Handle, Error> {
+    pub fn import(
+        &self,
+        handles: &HandleManagers,
+        encoded: &[u8],
+        encoding: KeyPairEncoding,
+    ) -> Result<Handle, Error> {
         match encoding {
             KeyPairEncoding::PKCS8 => {}
             _ => bail!(CryptoError::UnsupportedEncoding),
         };
         let kp = RSASignatureKeyPair::from_pkcs8(self.alg, encoded)?;
-        let handle = WASI_CRYPTO_CTX
-            .signature_keypair_manager
+        let handle = handles
+            .signature_keypair
             .register(SignatureKeyPair::RSA(kp))?;
         Ok(handle)
     }

--- a/proposals/poc/implementation/src/signature_keypair.rs
+++ b/proposals/poc/implementation/src/signature_keypair.rs
@@ -151,12 +151,12 @@ impl WasiCryptoCtx {
         _kp_id: &[u8],
         _kp_version: Version,
     ) -> Result<Handle, Error> {
-        bail!(CryptoError::UnsupportedOperation)
+        bail!(CryptoError::UnsupportedFeature)
     }
 
     pub fn signature_keypair_id(&self, kp_handle: Handle) -> Result<(Handle, Version), Error> {
         let _kp = self.handles.signature_keypair.get(kp_handle)?;
-        bail!(CryptoError::UnsupportedOperation)
+        bail!(CryptoError::UnsupportedFeature)
     }
 
     pub fn signature_keypair_invalidate(
@@ -165,7 +165,7 @@ impl WasiCryptoCtx {
         _kp_id: &[u8],
         _kp_version: Version,
     ) -> Result<(), Error> {
-        bail!(CryptoError::UnsupportedOperation)
+        bail!(CryptoError::UnsupportedFeature)
     }
 
     pub fn signature_keypair_export(

--- a/proposals/poc/implementation/src/signature_keypair.rs
+++ b/proposals/poc/implementation/src/signature_keypair.rs
@@ -1,3 +1,4 @@
+use super::array_output::*;
 use super::ecdsa::*;
 use super::eddsa::*;
 use super::error::*;
@@ -5,15 +6,15 @@ use super::handles::*;
 use super::rsa::*;
 use super::signature_op::*;
 use super::signature_publickey::*;
-use super::WASI_CRYPTO_CTX;
+use super::{HandleManagers, WasiCryptoCtx};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Version(u64);
 
 impl Version {
-    pub const UNSPECIFIED: Version = Version(0xff00000000000000);
-    pub const LATEST: Version = Version(0xff00000000000000);
-    pub const ALL: Version = Version(0xff00000000000000);
+    pub const UNSPECIFIED: Version = Version(0xff00_0000_0000_0000);
+    pub const LATEST: Version = Version(0xff00_0000_0000_0000);
+    pub const ALL: Version = Version(0xff00_0000_0000_0000);
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -45,35 +46,38 @@ impl SignatureKeyPair {
         Ok(encoded)
     }
 
-    fn generate(kp_builder_handle: Handle) -> Result<Handle, Error> {
-        let kp_builder = WASI_CRYPTO_CTX
-            .signature_keypair_builder_manager
-            .get(kp_builder_handle)?;
+    fn generate(handles: &HandleManagers, kp_builder_handle: Handle) -> Result<Handle, Error> {
+        let kp_builder = handles.signature_keypair_builder.get(kp_builder_handle)?;
         let handle = match kp_builder {
-            SignatureKeyPairBuilder::ECDSA(kp_builder) => kp_builder.generate()?,
-            SignatureKeyPairBuilder::EdDSA(kp_builder) => kp_builder.generate()?,
-            SignatureKeyPairBuilder::RSA(kp_builder) => kp_builder.generate()?,
+            SignatureKeyPairBuilder::ECDSA(kp_builder) => kp_builder.generate(handles)?,
+            SignatureKeyPairBuilder::EdDSA(kp_builder) => kp_builder.generate(handles)?,
+            SignatureKeyPairBuilder::RSA(kp_builder) => kp_builder.generate(handles)?,
         };
         Ok(handle)
     }
 
     fn import(
+        handles: &HandleManagers,
         kp_builder_handle: Handle,
         encoded: &[u8],
         encoding: KeyPairEncoding,
     ) -> Result<Handle, Error> {
-        let kp_builder = WASI_CRYPTO_CTX
-            .signature_keypair_builder_manager
-            .get(kp_builder_handle)?;
+        let kp_builder = handles.signature_keypair_builder.get(kp_builder_handle)?;
         let handle = match kp_builder {
-            SignatureKeyPairBuilder::ECDSA(kp_builder) => kp_builder.import(encoded, encoding)?,
-            SignatureKeyPairBuilder::EdDSA(kp_builder) => kp_builder.import(encoded, encoding)?,
-            SignatureKeyPairBuilder::RSA(kp_builder) => kp_builder.import(encoded, encoding)?,
+            SignatureKeyPairBuilder::ECDSA(kp_builder) => {
+                kp_builder.import(handles, encoded, encoding)?
+            }
+            SignatureKeyPairBuilder::EdDSA(kp_builder) => {
+                kp_builder.import(handles, encoded, encoding)?
+            }
+            SignatureKeyPairBuilder::RSA(kp_builder) => {
+                kp_builder.import(handles, encoded, encoding)?
+            }
         };
         Ok(handle)
     }
 
-    fn public_key(&self) -> Result<Handle, Error> {
+    fn public_key(&self, handles: &HandleManagers) -> Result<Handle, Error> {
         let pk = match self {
             SignatureKeyPair::ECDSA(kp) => {
                 let raw_pk = kp.raw_public_key();
@@ -88,7 +92,7 @@ impl SignatureKeyPair {
                 SignaturePublicKey::RSA(RSASignaturePublicKey::from_raw(kp.alg, raw_pk)?)
             }
         };
-        let handle = WASI_CRYPTO_CTX.signature_publickey_manager.register(pk)?;
+        let handle = handles.signature_publickey.register(pk)?;
         Ok(handle)
     }
 }
@@ -101,8 +105,8 @@ pub enum SignatureKeyPairBuilder {
 }
 
 impl SignatureKeyPairBuilder {
-    fn open(op_handle: Handle) -> Result<Handle, Error> {
-        let signature_op = WASI_CRYPTO_CTX.signature_op_manager.get(op_handle)?;
+    fn open(handles: &HandleManagers, op_handle: Handle) -> Result<Handle, Error> {
+        let signature_op = handles.signature_op.get(op_handle)?;
         let kp_builder = match signature_op {
             SignatureOp::ECDSA(_) => SignatureKeyPairBuilder::ECDSA(
                 ECDSASignatureKeyPairBuilder::new(signature_op.alg()),
@@ -114,71 +118,74 @@ impl SignatureKeyPairBuilder {
                 SignatureKeyPairBuilder::RSA(RSASignatureKeyPairBuilder::new(signature_op.alg()))
             }
         };
-        let handle = WASI_CRYPTO_CTX
-            .signature_keypair_builder_manager
-            .register(kp_builder)?;
+        let handle = handles.signature_keypair_builder.register(kp_builder)?;
         Ok(handle)
     }
 }
 
-pub fn signature_keypair_builder_open(op_handle: Handle) -> Result<Handle, Error> {
-    SignatureKeyPairBuilder::open(op_handle)
-}
+impl WasiCryptoCtx {
+    pub fn signature_keypair_builder_open(&self, op_handle: Handle) -> Result<Handle, Error> {
+        SignatureKeyPairBuilder::open(&self.handles, op_handle)
+    }
 
-pub fn signature_keypair_builder_close(handle: Handle) -> Result<(), Error> {
-    WASI_CRYPTO_CTX
-        .signature_keypair_builder_manager
-        .close(handle)
-}
+    pub fn signature_keypair_builder_close(&self, handle: Handle) -> Result<(), Error> {
+        self.handles.signature_keypair_builder.close(handle)
+    }
 
-pub fn signature_keypair_generate(kp_builder_handle: Handle) -> Result<Handle, Error> {
-    SignatureKeyPair::generate(kp_builder_handle)
-}
+    pub fn signature_keypair_generate(&self, kp_builder_handle: Handle) -> Result<Handle, Error> {
+        SignatureKeyPair::generate(&self.handles, kp_builder_handle)
+    }
 
-pub fn signature_keypair_import(
-    kp_builder_handle: Handle,
-    encoded: &[u8],
-    encoding: KeyPairEncoding,
-) -> Result<Handle, Error> {
-    SignatureKeyPair::import(kp_builder_handle, encoded, encoding)
-}
+    pub fn signature_keypair_import(
+        &self,
+        kp_builder_handle: Handle,
+        encoded: &[u8],
+        encoding: KeyPairEncoding,
+    ) -> Result<Handle, Error> {
+        SignatureKeyPair::import(&self.handles, kp_builder_handle, encoded, encoding)
+    }
 
-pub fn signature_keypair_from_id(
-    _kp_builder_handle: Handle,
-    _kp_id: &[u8],
-    _kp_version: Version,
-) -> Result<Handle, Error> {
-    bail!(CryptoError::UnsupportedOperation)
-}
+    pub fn signature_keypair_from_id(
+        &self,
+        _kp_builder_handle: Handle,
+        _kp_id: &[u8],
+        _kp_version: Version,
+    ) -> Result<Handle, Error> {
+        bail!(CryptoError::UnsupportedOperation)
+    }
 
-pub fn signature_keypair_id(kp_handle: Handle) -> Result<(Vec<u8>, Version), Error> {
-    let _kp = WASI_CRYPTO_CTX.signature_keypair_manager.get(kp_handle)?;
-    bail!(CryptoError::UnsupportedOperation)
-}
+    pub fn signature_keypair_id(&self, kp_handle: Handle) -> Result<(Handle, Version), Error> {
+        let _kp = self.handles.signature_keypair.get(kp_handle)?;
+        bail!(CryptoError::UnsupportedOperation)
+    }
 
-pub fn signature_keypair_invalidate(
-    _kp_builder_handle: Handle,
-    _kp_id: &[u8],
-    _kp_version: Version,
-) -> Result<(), Error> {
-    bail!(CryptoError::UnsupportedOperation)
-}
+    pub fn signature_keypair_invalidate(
+        &self,
+        _kp_builder_handle: Handle,
+        _kp_id: &[u8],
+        _kp_version: Version,
+    ) -> Result<(), Error> {
+        bail!(CryptoError::UnsupportedOperation)
+    }
 
-pub fn signature_keypair_export(
-    kp_handle: Handle,
-    encoding: KeyPairEncoding,
-) -> Result<Vec<u8>, Error> {
-    let kp = WASI_CRYPTO_CTX.signature_keypair_manager.get(kp_handle)?;
-    let encoded = kp.export(encoding)?;
-    Ok(encoded)
-}
+    pub fn signature_keypair_export(
+        &self,
+        kp_handle: Handle,
+        encoding: KeyPairEncoding,
+    ) -> Result<Handle, Error> {
+        let kp = self.handles.signature_keypair.get(kp_handle)?;
+        let encoded = kp.export(encoding)?;
+        let array_output_handle = ArrayOutput::register(&self.handles, encoded)?;
+        Ok(array_output_handle)
+    }
 
-pub fn signature_keypair_publickey(kp_handle: Handle) -> Result<Handle, Error> {
-    let kp = WASI_CRYPTO_CTX.signature_keypair_manager.get(kp_handle)?;
-    let handle = kp.public_key()?;
-    Ok(handle)
-}
+    pub fn signature_keypair_publickey(&self, kp_handle: Handle) -> Result<Handle, Error> {
+        let kp = self.handles.signature_keypair.get(kp_handle)?;
+        let handle = kp.public_key(&self.handles)?;
+        Ok(handle)
+    }
 
-pub fn signature_keypair_close(handle: Handle) -> Result<(), Error> {
-    WASI_CRYPTO_CTX.signature_keypair_manager.close(handle)
+    pub fn signature_keypair_close(&self, handle: Handle) -> Result<(), Error> {
+        self.handles.signature_keypair.close(handle)
+    }
 }

--- a/proposals/poc/implementation/src/signature_publickey.rs
+++ b/proposals/poc/implementation/src/signature_publickey.rs
@@ -73,7 +73,7 @@ impl SignaturePublicKey {
     }
 
     fn verify(_pk_handle: Handle) -> Result<(), Error> {
-        bail!(CryptoError::UnsupportedOperation)
+        bail!(CryptoError::NotImplemented)
     }
 }
 

--- a/proposals/poc/implementation/src/signature_publickey.rs
+++ b/proposals/poc/implementation/src/signature_publickey.rs
@@ -1,10 +1,11 @@
+use super::array_output::*;
 use super::ecdsa::*;
 use super::eddsa::*;
 use super::error::*;
 use super::handles::*;
 use super::rsa::*;
 use super::signature_op::*;
-use super::WASI_CRYPTO_CTX;
+use super::{HandleManagers, WasiCryptoCtx};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u16)]
@@ -26,6 +27,7 @@ pub enum SignaturePublicKey {
 
 impl SignaturePublicKey {
     fn import(
+        handles: &HandleManagers,
         signature_op: Handle,
         encoded: &[u8],
         encoding: PublicKeyEncoding,
@@ -34,7 +36,7 @@ impl SignaturePublicKey {
             PublicKeyEncoding::Raw => {}
             _ => bail!(CryptoError::UnsupportedEncoding),
         }
-        let signature_op = WASI_CRYPTO_CTX.signature_op_manager.get(signature_op)?;
+        let signature_op = handles.signature_op.get(signature_op)?;
         let pk =
             match signature_op {
                 SignatureOp::ECDSA(_) => SignaturePublicKey::ECDSA(
@@ -48,16 +50,20 @@ impl SignaturePublicKey {
                     encoded,
                 )?),
             };
-        let handle = WASI_CRYPTO_CTX.signature_publickey_manager.register(pk)?;
+        let handle = handles.signature_publickey.register(pk)?;
         Ok(handle)
     }
 
-    fn export(pk: Handle, encoding: PublicKeyEncoding) -> Result<Vec<u8>, Error> {
+    fn export(
+        handles: &HandleManagers,
+        pk: Handle,
+        encoding: PublicKeyEncoding,
+    ) -> Result<Vec<u8>, Error> {
         match encoding {
             PublicKeyEncoding::Raw => {}
             _ => bail!(CryptoError::UnsupportedEncoding),
         }
-        let pk = WASI_CRYPTO_CTX.signature_publickey_manager.get(pk)?;
+        let pk = handles.signature_publickey.get(pk)?;
         let raw_pk = match pk {
             SignaturePublicKey::ECDSA(pk) => pk.as_raw()?.to_vec(),
             SignaturePublicKey::EdDSA(pk) => pk.as_raw()?.to_vec(),
@@ -71,25 +77,31 @@ impl SignaturePublicKey {
     }
 }
 
-pub fn signature_publickey_import(
-    signature_op: Handle,
-    encoded: &[u8],
-    encoding: PublicKeyEncoding,
-) -> Result<Handle, Error> {
-    SignaturePublicKey::import(signature_op, encoded, encoding)
-}
+impl WasiCryptoCtx {
+    pub fn signature_publickey_import(
+        &self,
+        signature_op: Handle,
+        encoded: &[u8],
+        encoding: PublicKeyEncoding,
+    ) -> Result<Handle, Error> {
+        SignaturePublicKey::import(&self.handles, signature_op, encoded, encoding)
+    }
 
-pub fn signature_publickey_export(
-    pk: Handle,
-    encoding: PublicKeyEncoding,
-) -> Result<Vec<u8>, Error> {
-    SignaturePublicKey::export(pk, encoding)
-}
+    pub fn signature_publickey_export(
+        &self,
+        pk: Handle,
+        encoding: PublicKeyEncoding,
+    ) -> Result<Handle, Error> {
+        let encoded = SignaturePublicKey::export(&self.handles, pk, encoding)?;
+        let array_output_handle = ArrayOutput::register(&self.handles, encoded)?;
+        Ok(array_output_handle)
+    }
 
-pub fn signature_publickey_verify(pk: Handle) -> Result<(), Error> {
-    SignaturePublicKey::verify(pk)
-}
+    pub fn signature_publickey_verify(&self, pk: Handle) -> Result<(), Error> {
+        SignaturePublicKey::verify(pk)
+    }
 
-pub fn signature_publickey_close(handle: Handle) -> Result<(), Error> {
-    WASI_CRYPTO_CTX.signature_publickey_manager.close(handle)
+    pub fn signature_publickey_close(&self, handle: Handle) -> Result<(), Error> {
+        self.handles.signature_publickey.close(handle)
+    }
 }

--- a/proposals/poc/witx/proposal_signatures.md
+++ b/proposals/poc/witx/proposal_signatures.md
@@ -4,27 +4,31 @@
 ### Variants
 - <a href="#crypto_errno.success" name="crypto_errno.success"></a> `success`
 
-- <a href="#crypto_errno.unsupportedoperation" name="crypto_errno.unsupportedoperation"></a> `unsupportedoperation`
+- <a href="#crypto_errno.unsupported_operation" name="crypto_errno.unsupported_operation"></a> `unsupported_operation`
 
-- <a href="#crypto_errno.unsupportedencoding" name="crypto_errno.unsupportedencoding"></a> `unsupportedencoding`
+- <a href="#crypto_errno.unsupported_encoding" name="crypto_errno.unsupported_encoding"></a> `unsupported_encoding`
 
-- <a href="#crypto_errno.unsupportedalgorithm" name="crypto_errno.unsupportedalgorithm"></a> `unsupportedalgorithm`
+- <a href="#crypto_errno.unsupported_algorithm" name="crypto_errno.unsupported_algorithm"></a> `unsupported_algorithm`
 
-- <a href="#crypto_errno.invalidkey" name="crypto_errno.invalidkey"></a> `invalidkey`
+- <a href="#crypto_errno.invalid_key" name="crypto_errno.invalid_key"></a> `invalid_key`
 
-- <a href="#crypto_errno.verificationfailed" name="crypto_errno.verificationfailed"></a> `verificationfailed`
+- <a href="#crypto_errno.verification_failed" name="crypto_errno.verification_failed"></a> `verification_failed`
 
-- <a href="#crypto_errno.rngerror" name="crypto_errno.rngerror"></a> `rngerror`
+- <a href="#crypto_errno.rng_error" name="crypto_errno.rng_error"></a> `rng_error`
 
-- <a href="#crypto_errno.algorithmfailure" name="crypto_errno.algorithmfailure"></a> `algorithmfailure`
+- <a href="#crypto_errno.algorithm_failure" name="crypto_errno.algorithm_failure"></a> `algorithm_failure`
 
-- <a href="#crypto_errno.invalidsignature" name="crypto_errno.invalidsignature"></a> `invalidsignature`
+- <a href="#crypto_errno.invalid_signature" name="crypto_errno.invalid_signature"></a> `invalid_signature`
 
 - <a href="#crypto_errno.closed" name="crypto_errno.closed"></a> `closed`
 
-- <a href="#crypto_errno.invalidhandle" name="crypto_errno.invalidhandle"></a> `invalidhandle`
+- <a href="#crypto_errno.invalid_handle" name="crypto_errno.invalid_handle"></a> `invalid_handle`
 
 - <a href="#crypto_errno.overflow" name="crypto_errno.overflow"></a> `overflow`
+
+- <a href="#crypto_errno.internal_error" name="crypto_errno.internal_error"></a> `internal_error`
+
+- <a href="#crypto_errno.too_many_handles" name="crypto_errno.too_many_handles"></a> `too_many_handles`
 
 ## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: Enum(`u16`)
 
@@ -198,7 +202,7 @@ Destroy a key pair builder.
 
 #### <a href="#signature_keypair_generate" name="signature_keypair_generate"></a> `signature_keypair_generate(kp_builder: signature_keypair_builder) -> (crypto_errno, signature_keypair)`
 Generate a new key pair.
-This function may return crypto_errno.unsupportedoperation if key
+This function may return crypto_errno.unsupported_operation if key
 generation is not supported by the host for the chosen algorithm.
 
 ##### Params
@@ -214,8 +218,8 @@ generation is not supported by the host for the chosen algorithm.
 
 #### <a href="#signature_keypair_import" name="signature_keypair_import"></a> `signature_keypair_import(kp_builder: signature_keypair_builder, encoded: ConstPointer<u8>, encoded_len: size, encoding: keypair_encoding) -> (crypto_errno, signature_keypair)`
 Import a key pair.
-This function may return crypto_errno.unsupportedalgorithm if the
-encoding scheme is not supported, or crypto_errno.invalidkey if the key
+This function may return crypto_errno.unsupported_algorithm if the
+encoding scheme is not supported, or crypto_errno.invalid_key if the key
 cannot be decoded.
 
 ##### Params
@@ -237,7 +241,7 @@ cannot be decoded.
 
 #### <a href="#signature_keypair_id" name="signature_keypair_id"></a> `signature_keypair_id(kp: signature_keypair, kp_id: ConstPointer<u8>, kp_id_max_len: size) -> (crypto_errno, size, version)`
 Return the key identifier and version, if these are available
-or $crypto_errno.unsupportedoperation if not.
+or $crypto_errno.unsupported_operation if not.
 
 ##### Params
 - <a href="#signature_keypair_id.kp" name="signature_keypair_id.kp"></a> `kp`: [`signature_keypair`](#signature_keypair)
@@ -258,8 +262,8 @@ or $crypto_errno.unsupportedoperation if not.
 
 #### <a href="#signature_keypair_from_id" name="signature_keypair_from_id"></a> `signature_keypair_from_id(kp_builder: signature_keypair_builder, kp_id: ConstPointer<u8>, kp_id_len: size, kp_version: version) -> (crypto_errno, signature_keypair)`
 Create a key pair using an opaque key identifier.
-Return crypto_errno.unsupportedoperation if this operation is not
-supported by the host, and crypto_errno.invalidkey if the identifier
+Return crypto_errno.unsupported_operation if this operation is not
+supported by the host, and crypto_errno.invalid_key if the identifier
 is invalid.
 The version can be an actual version number or $version.latest .
 
@@ -282,8 +286,8 @@ The version can be an actual version number or $version.latest .
 
 #### <a href="#signature_keypair_invalidate" name="signature_keypair_invalidate"></a> `signature_keypair_invalidate(kp_builder: signature_keypair_builder, kp_id: ConstPointer<u8>, kp_id_len: size, kp_version: version) -> crypto_errno`
 Invalidate a key pair given a key identifier and a version.
-Return crypto_errno.unsupportedoperation if this operation is not
-supported by the host, and crypto_errno.invalidkey if the identifier
+Return crypto_errno.unsupported_operation if this operation is not
+supported by the host, and crypto_errno.invalid_key if the identifier
 is invalid.
 The version can be a actual version number, as well as
 $version.latest or $version.all .
@@ -305,8 +309,8 @@ $version.latest or $version.all .
 
 #### <a href="#signature_keypair_export" name="signature_keypair_export"></a> `signature_keypair_export(kp: signature_keypair, encoding: keypair_encoding) -> (crypto_errno, array_output)`
 Export the key pair as the given encoding format.
-May return crypto_errno.unsupportedoperation if this operation is
-not supported or crypto_errno.unsupportedencoding if the encoding
+May return crypto_errno.unsupported_operation if this operation is
+not supported or crypto_errno.unsupported_encoding if the encoding
 is not supported.
 
 ##### Params
@@ -350,8 +354,8 @@ Destroys a key pair and wipe memory accordingly.
 
 #### <a href="#signature_publickey_import" name="signature_publickey_import"></a> `signature_publickey_import(signature_op: signature_op, encoded: ConstPointer<u8>, encoded_len: size, encoding: publickey_encoding) -> (crypto_errno, signature_publickey)`
 Import a public key encoded.
-Return crypto_errno.unsupportedoperation if this operation is not
-supported by the host and crypto_errno.unsupportedencoding if exporting
+Return crypto_errno.unsupported_operation if this operation is not
+supported by the host and crypto_errno.unsupported_encoding if exporting
 to the given format is not implemented or if the format is
 incompatible with the key type.
 
@@ -374,7 +378,7 @@ incompatible with the key type.
 
 #### <a href="#signature_publickey_verify" name="signature_publickey_verify"></a> `signature_publickey_verify(pk: signature_publickey) -> crypto_errno`
 Check that a public key is valid and in canonical form.
-Return crypto_errno.invalidkey is verification fails.
+Return crypto_errno.invalid_key is verification fails.
 
 ##### Params
 - <a href="#signature_publickey_verify.pk" name="signature_publickey_verify.pk"></a> `pk`: [`signature_publickey`](#signature_publickey)
@@ -416,7 +420,7 @@ Export a signature in the given format.
 #### <a href="#signature_import" name="signature_import"></a> `signature_import(signature_op: signature_op, encoding: signature_encoding, encoded: ConstPointer<u8>, encoded_len: size) -> (crypto_errno, signature)`
 Create a signature object by importing a signature encoded
 in a given format.
-Return crypto_errno.invalidsignature if the signature is incompatible
+Return crypto_errno.invalid_signature if the signature is incompatible
 with the current content.
 
 ##### Params

--- a/proposals/poc/witx/proposal_signatures.md
+++ b/proposals/poc/witx/proposal_signatures.md
@@ -4,7 +4,11 @@
 ### Variants
 - <a href="#crypto_errno.success" name="crypto_errno.success"></a> `success`
 
-- <a href="#crypto_errno.unsupported_operation" name="crypto_errno.unsupported_operation"></a> `unsupported_operation`
+- <a href="#crypto_errno.not_implemented" name="crypto_errno.not_implemented"></a> `not_implemented`
+
+- <a href="#crypto_errno.unsupported_feature" name="crypto_errno.unsupported_feature"></a> `unsupported_feature`
+
+- <a href="#crypto_errno.prohibited_operation" name="crypto_errno.prohibited_operation"></a> `prohibited_operation`
 
 - <a href="#crypto_errno.unsupported_encoding" name="crypto_errno.unsupported_encoding"></a> `unsupported_encoding`
 
@@ -202,7 +206,7 @@ Destroy a key pair builder.
 
 #### <a href="#signature_keypair_generate" name="signature_keypair_generate"></a> `signature_keypair_generate(kp_builder: signature_keypair_builder) -> (crypto_errno, signature_keypair)`
 Generate a new key pair.
-This function may return crypto_errno.unsupported_operation if key
+This function may return crypto_errno.unsupported_feature if key
 generation is not supported by the host for the chosen algorithm.
 
 ##### Params
@@ -240,8 +244,9 @@ cannot be decoded.
 ---
 
 #### <a href="#signature_keypair_id" name="signature_keypair_id"></a> `signature_keypair_id(kp: signature_keypair, kp_id: ConstPointer<u8>, kp_id_max_len: size) -> (crypto_errno, size, version)`
+[OPTIONAL IMPORT]
 Return the key identifier and version, if these are available
-or $crypto_errno.unsupported_operation if not.
+or $crypto_errno.unsupported_feature if not.
 
 ##### Params
 - <a href="#signature_keypair_id.kp" name="signature_keypair_id.kp"></a> `kp`: [`signature_keypair`](#signature_keypair)
@@ -261,8 +266,9 @@ or $crypto_errno.unsupported_operation if not.
 ---
 
 #### <a href="#signature_keypair_from_id" name="signature_keypair_from_id"></a> `signature_keypair_from_id(kp_builder: signature_keypair_builder, kp_id: ConstPointer<u8>, kp_id_len: size, kp_version: version) -> (crypto_errno, signature_keypair)`
+[OPTIONAL IMPORT]
 Create a key pair using an opaque key identifier.
-Return crypto_errno.unsupported_operation if this operation is not
+Return crypto_errno.unsupported_feature if this operation is not
 supported by the host, and crypto_errno.invalid_key if the identifier
 is invalid.
 The version can be an actual version number or $version.latest .
@@ -285,8 +291,9 @@ The version can be an actual version number or $version.latest .
 ---
 
 #### <a href="#signature_keypair_invalidate" name="signature_keypair_invalidate"></a> `signature_keypair_invalidate(kp_builder: signature_keypair_builder, kp_id: ConstPointer<u8>, kp_id_len: size, kp_version: version) -> crypto_errno`
+[OPTIONAL IMPORT]
 Invalidate a key pair given a key identifier and a version.
-Return crypto_errno.unsupported_operation if this operation is not
+Return crypto_errno.unsupported_feature if this operation is not
 supported by the host, and crypto_errno.invalid_key if the identifier
 is invalid.
 The version can be a actual version number, as well as
@@ -308,9 +315,10 @@ $version.latest or $version.all .
 ---
 
 #### <a href="#signature_keypair_export" name="signature_keypair_export"></a> `signature_keypair_export(kp: signature_keypair, encoding: keypair_encoding) -> (crypto_errno, array_output)`
+[OPTIONAL IMPORT]
 Export the key pair as the given encoding format.
-May return crypto_errno.unsupported_operation if this operation is
-not supported or crypto_errno.unsupported_encoding if the encoding
+May return crypto_errno.prohibited_operation if this operation is
+not available or crypto_errno.unsupported_encoding if the encoding
 is not supported.
 
 ##### Params
@@ -354,8 +362,7 @@ Destroys a key pair and wipe memory accordingly.
 
 #### <a href="#signature_publickey_import" name="signature_publickey_import"></a> `signature_publickey_import(signature_op: signature_op, encoded: ConstPointer<u8>, encoded_len: size, encoding: publickey_encoding) -> (crypto_errno, signature_publickey)`
 Import a public key encoded.
-Return crypto_errno.unsupported_operation if this operation is not
-supported by the host and crypto_errno.unsupported_encoding if exporting
+Return crypto_errno.unsupported_encoding if exporting
 to the given format is not implemented or if the format is
 incompatible with the key type.
 

--- a/proposals/poc/witx/proposal_signatures.witx
+++ b/proposals/poc/witx/proposal_signatures.witx
@@ -3,17 +3,19 @@
 (typename $crypto_errno
   (enum u16
     $success
-    $unsupportedoperation
-    $unsupportedencoding
-    $unsupportedalgorithm
-    $invalidkey
-    $verificationfailed
-    $rngerror
-    $algorithmfailure
-    $invalidsignature
+    $unsupported_operation
+    $unsupported_encoding
+    $unsupported_algorithm
+    $invalid_key
+    $verification_failed
+    $rng_error
+    $algorithm_failure
+    $invalid_signature
     $closed
-    $invalidhandle
+    $invalid_handle
     $overflow
+    $internal_error
+    $too_many_handles
   )
 )
 
@@ -116,7 +118,7 @@
   )
 
   ;;; Generate a new key pair.
-  ;;; This function may return crypto_errno.unsupportedoperation if key
+  ;;; This function may return crypto_errno.unsupported_operation if key
   ;;; generation is not supported by the host for the chosen algorithm.
   (@interface func (export "signature_keypair_generate")
     (param $kp_builder $signature_keypair_builder)
@@ -125,8 +127,8 @@
   )
 
   ;;; Import a key pair.
-  ;;; This function may return crypto_errno.unsupportedalgorithm if the
-  ;;; encoding scheme is not supported, or crypto_errno.invalidkey if the key
+  ;;; This function may return crypto_errno.unsupported_algorithm if the
+  ;;; encoding scheme is not supported, or crypto_errno.invalid_key if the key
   ;;; cannot be decoded.
   (@interface func (export "signature_keypair_import")
     (param $kp_builder $signature_keypair_builder)
@@ -138,7 +140,7 @@
   )
 
   ;;; Return the key identifier and version, if these are available
-  ;;; or $crypto_errno.unsupportedoperation if not.
+  ;;; or $crypto_errno.unsupported_operation if not.
   (@interface func (export "signature_keypair_id")
     (param $kp $signature_keypair)
     (param $kp_id (@witx const_pointer u8))
@@ -149,8 +151,8 @@
   )
 
   ;;; Create a key pair using an opaque key identifier.
-  ;;; Return crypto_errno.unsupportedoperation if this operation is not
-  ;;; supported by the host, and crypto_errno.invalidkey if the identifier
+  ;;; Return crypto_errno.unsupported_operation if this operation is not
+  ;;; supported by the host, and crypto_errno.invalid_key if the identifier
   ;;; is invalid.
   ;;; The version can be an actual version number or $version.latest .
   (@interface func (export "signature_keypair_from_id")
@@ -163,8 +165,8 @@
   )
 
   ;;; Invalidate a key pair given a key identifier and a version.
-  ;;; Return crypto_errno.unsupportedoperation if this operation is not
-  ;;; supported by the host, and crypto_errno.invalidkey if the identifier
+  ;;; Return crypto_errno.unsupported_operation if this operation is not
+  ;;; supported by the host, and crypto_errno.invalid_key if the identifier
   ;;; is invalid.
   ;;; The version can be a actual version number, as well as
   ;;; $version.latest or $version.all .
@@ -177,8 +179,8 @@
   )
 
   ;;; Export the key pair as the given encoding format.
-  ;;; May return crypto_errno.unsupportedoperation if this operation is
-  ;;; not supported or crypto_errno.unsupportedencoding if the encoding
+  ;;; May return crypto_errno.unsupported_operation if this operation is
+  ;;; not supported or crypto_errno.unsupported_encoding if the encoding
   ;;; is not supported.
   (@interface func (export "signature_keypair_export")
     (param $kp $signature_keypair)
@@ -201,8 +203,8 @@
   )
 
   ;;; Import a public key encoded.
-  ;;; Return crypto_errno.unsupportedoperation if this operation is not
-  ;;; supported by the host and crypto_errno.unsupportedencoding if exporting
+  ;;; Return crypto_errno.unsupported_operation if this operation is not
+  ;;; supported by the host and crypto_errno.unsupported_encoding if exporting
   ;;; to the given format is not implemented or if the format is
   ;;; incompatible with the key type.
   (@interface func (export "signature_publickey_import")
@@ -215,7 +217,7 @@
   )
 
   ;;; Check that a public key is valid and in canonical form.
-  ;;; Return crypto_errno.invalidkey is verification fails.
+  ;;; Return crypto_errno.invalid_key is verification fails.
   (@interface func (export "signature_publickey_verify")
     (param $pk $signature_publickey)
     (result $error $crypto_errno)
@@ -237,7 +239,7 @@
 
   ;;; Create a signature object by importing a signature encoded
   ;;; in a given format.
-  ;;; Return crypto_errno.invalidsignature if the signature is incompatible
+  ;;; Return crypto_errno.invalid_signature if the signature is incompatible
   ;;; with the current content.
   (@interface func (export "signature_import")
     (param $signature_op $signature_op)

--- a/proposals/poc/witx/proposal_signatures.witx
+++ b/proposals/poc/witx/proposal_signatures.witx
@@ -3,7 +3,9 @@
 (typename $crypto_errno
   (enum u16
     $success
-    $unsupported_operation
+    $not_implemented
+    $unsupported_feature
+    $prohibited_operation
     $unsupported_encoding
     $unsupported_algorithm
     $invalid_key
@@ -118,7 +120,7 @@
   )
 
   ;;; Generate a new key pair.
-  ;;; This function may return crypto_errno.unsupported_operation if key
+  ;;; This function may return crypto_errno.unsupported_feature if key
   ;;; generation is not supported by the host for the chosen algorithm.
   (@interface func (export "signature_keypair_generate")
     (param $kp_builder $signature_keypair_builder)
@@ -139,8 +141,9 @@
     (result $handle $signature_keypair)
   )
 
+  ;;; [OPTIONAL IMPORT]
   ;;; Return the key identifier and version, if these are available
-  ;;; or $crypto_errno.unsupported_operation if not.
+  ;;; or $crypto_errno.unsupported_feature if not.
   (@interface func (export "signature_keypair_id")
     (param $kp $signature_keypair)
     (param $kp_id (@witx const_pointer u8))
@@ -150,8 +153,9 @@
     (result $version $version)
   )
 
+  ;;; [OPTIONAL IMPORT]
   ;;; Create a key pair using an opaque key identifier.
-  ;;; Return crypto_errno.unsupported_operation if this operation is not
+  ;;; Return crypto_errno.unsupported_feature if this operation is not
   ;;; supported by the host, and crypto_errno.invalid_key if the identifier
   ;;; is invalid.
   ;;; The version can be an actual version number or $version.latest .
@@ -164,8 +168,9 @@
     (result $handle $signature_keypair)
   )
 
+  ;;; [OPTIONAL IMPORT]
   ;;; Invalidate a key pair given a key identifier and a version.
-  ;;; Return crypto_errno.unsupported_operation if this operation is not
+  ;;; Return crypto_errno.unsupported_feature if this operation is not
   ;;; supported by the host, and crypto_errno.invalid_key if the identifier
   ;;; is invalid.
   ;;; The version can be a actual version number, as well as
@@ -178,9 +183,10 @@
     (result $error $crypto_errno)
   )
 
+  ;;; [OPTIONAL IMPORT]
   ;;; Export the key pair as the given encoding format.
-  ;;; May return crypto_errno.unsupported_operation if this operation is
-  ;;; not supported or crypto_errno.unsupported_encoding if the encoding
+  ;;; May return crypto_errno.prohibited_operation if this operation is
+  ;;; not available or crypto_errno.unsupported_encoding if the encoding
   ;;; is not supported.
   (@interface func (export "signature_keypair_export")
     (param $kp $signature_keypair)
@@ -203,8 +209,7 @@
   )
 
   ;;; Import a public key encoded.
-  ;;; Return crypto_errno.unsupported_operation if this operation is not
-  ;;; supported by the host and crypto_errno.unsupported_encoding if exporting
+  ;;; Return crypto_errno.unsupported_encoding if exporting
   ;;; to the given format is not implemented or if the format is
   ;;; incompatible with the key type.
   (@interface func (export "signature_publickey_import")


### PR DESCRIPTION
Prepare for integration in `lucet-runtime`&`wasmtime` with the help of `wiggle`:

- Remove the static handle managers, store all of these in a WASI context
- Use underscores in error names; it greatly improves readability, and
`wiggle` was designed to properly convert these to camel case
- Make all public functions members of the WASI context and change them to `wiggle`-ready; in particular, return `array_output` handles instead of `Vec<u8>`
- Implement and expose `array_output` methods