### PR TITLE
Implement the WASI interface for the signature API

### DIFF
--- a/proposals/poc/implementation/Cargo.toml
+++ b/proposals/poc/implementation/Cargo.toml
@@ -9,5 +9,6 @@ anyhow = "1.0"
 parking_lot = "0.10"
 ring = "0.16"
 thiserror = "1.0"
+wiggle = "0.1"
+wiggle-runtime = "0.1"
 zeroize = "1.1"
-

--- a/proposals/poc/implementation/src/array_output.rs
+++ b/proposals/poc/implementation/src/array_output.rs
@@ -2,7 +2,8 @@ use std::io::{Cursor, Read};
 
 use super::error::*;
 use super::handles::*;
-use super::{HandleManagers, WasiCryptoCtx};
+use super::types as guest_types;
+use super::{CryptoCtx, HandleManagers, WasiCryptoCtx};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ArrayOutput(Cursor<Vec<u8>>);
@@ -12,7 +13,7 @@ impl ArrayOutput {
         self.0.get_ref().len()
     }
 
-    fn pull(&self, buf: &mut [u8]) -> Result<usize, Error> {
+    fn pull(&self, buf: &mut [u8]) -> Result<usize, CryptoError> {
         let data = self.0.get_ref();
         let data_len = data.len();
         let buf_len = buf.len();
@@ -25,7 +26,7 @@ impl ArrayOutput {
         ArrayOutput(Cursor::new(data))
     }
 
-    pub fn register(handles: &HandleManagers, data: Vec<u8>) -> Result<Handle, Error> {
+    pub fn register(handles: &HandleManagers, data: Vec<u8>) -> Result<Handle, CryptoError> {
         let array_output = ArrayOutput::new(data);
         let handle = handles.array_output.register(array_output)?;
         Ok(handle)
@@ -38,8 +39,8 @@ impl Read for ArrayOutput {
     }
 }
 
-impl WasiCryptoCtx {
-    pub fn array_output_len(&self, array_output_handle: Handle) -> Result<usize, Error> {
+impl CryptoCtx {
+    pub fn array_output_len(&self, array_output_handle: Handle) -> Result<usize, CryptoError> {
         let array_output = self.handles.array_output.get(array_output_handle)?;
         Ok(array_output.len())
     }
@@ -48,10 +49,31 @@ impl WasiCryptoCtx {
         &self,
         array_output_handle: Handle,
         buf: &mut [u8],
-    ) -> Result<usize, Error> {
+    ) -> Result<usize, CryptoError> {
         let array_output = self.handles.array_output.get(array_output_handle)?;
         let len = array_output.pull(buf)?;
         self.handles.array_output.close(array_output_handle)?;
         Ok(len)
+    }
+}
+
+impl WasiCryptoCtx {
+    pub fn array_output_len(
+        &self,
+        array_output_handle: guest_types::ArrayOutput,
+    ) -> Result<usize, CryptoError> {
+        self.ctx.array_output_len(array_output_handle.into())
+    }
+
+    pub fn array_output_pull(
+        &self,
+        array_output_handle: guest_types::ArrayOutput,
+        buf_ptr: wiggle_runtime::GuestPtr<'_, u8>,
+        buf_len: guest_types::Size,
+    ) -> Result<usize, CryptoError> {
+        let mut guest_borrow = wiggle_runtime::GuestBorrows::new();
+        let buf: &mut [u8] =
+            unsafe { &mut *buf_ptr.as_array(buf_len as _).as_raw(&mut guest_borrow)? };
+        self.ctx.array_output_pull(array_output_handle.into(), buf)
     }
 }

--- a/proposals/poc/implementation/src/eddsa.rs
+++ b/proposals/poc/implementation/src/eddsa.rs
@@ -28,7 +28,7 @@ pub struct EdDSASignatureKeyPair {
 }
 
 impl EdDSASignatureKeyPair {
-    pub fn from_pkcs8(alg: SignatureAlgorithm, pkcs8: &[u8]) -> Result<Self, Error> {
+    pub fn from_pkcs8(alg: SignatureAlgorithm, pkcs8: &[u8]) -> Result<Self, CryptoError> {
         let ring_kp = ring::signature::Ed25519KeyPair::from_pkcs8(pkcs8)
             .map_err(|_| CryptoError::InvalidKey)?;
         let kp = EdDSASignatureKeyPair {
@@ -39,11 +39,11 @@ impl EdDSASignatureKeyPair {
         Ok(kp)
     }
 
-    pub fn as_pkcs8(&self) -> Result<&[u8], Error> {
+    pub fn as_pkcs8(&self) -> Result<&[u8], CryptoError> {
         Ok(&self.pkcs8)
     }
 
-    pub fn generate(alg: SignatureAlgorithm) -> Result<Self, Error> {
+    pub fn generate(alg: SignatureAlgorithm) -> Result<Self, CryptoError> {
         let rng = ring::rand::SystemRandom::new();
         let pkcs8 = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng)
             .map_err(|_| CryptoError::RNGError)?;
@@ -71,7 +71,7 @@ impl EdDSASignatureKeyPairBuilder {
         EdDSASignatureKeyPairBuilder { alg }
     }
 
-    pub fn generate(&self, handles: &HandleManagers) -> Result<Handle, Error> {
+    pub fn generate(&self, handles: &HandleManagers) -> Result<Handle, CryptoError> {
         let kp = EdDSASignatureKeyPair::generate(self.alg)?;
         let handle = handles
             .signature_keypair
@@ -84,7 +84,7 @@ impl EdDSASignatureKeyPairBuilder {
         handles: &HandleManagers,
         encoded: &[u8],
         encoding: KeyPairEncoding,
-    ) -> Result<Handle, Error> {
+    ) -> Result<Handle, CryptoError> {
         match encoding {
             KeyPairEncoding::PKCS8 => {}
             _ => bail!(CryptoError::UnsupportedEncoding),
@@ -126,12 +126,12 @@ impl EdDSASignatureState {
         }
     }
 
-    pub fn update(&self, input: &[u8]) -> Result<(), Error> {
+    pub fn update(&self, input: &[u8]) -> Result<(), CryptoError> {
         self.input.lock().extend_from_slice(input);
         Ok(())
     }
 
-    pub fn sign(&self) -> Result<EdDSASignature, Error> {
+    pub fn sign(&self) -> Result<EdDSASignature, CryptoError> {
         let input = self.input.lock();
         let signature_u8 = self.kp.ring_kp.sign(&input).as_ref().to_vec();
         let signature = EdDSASignature(signature_u8);
@@ -153,12 +153,12 @@ impl EdDSASignatureVerificationState {
         }
     }
 
-    pub fn update(&self, input: &[u8]) -> Result<(), Error> {
+    pub fn update(&self, input: &[u8]) -> Result<(), CryptoError> {
         self.input.lock().extend_from_slice(input);
         Ok(())
     }
 
-    pub fn verify(&self, signature: &EdDSASignature) -> Result<(), Error> {
+    pub fn verify(&self, signature: &EdDSASignature) -> Result<(), CryptoError> {
         let ring_alg = match self.pk.alg {
             SignatureAlgorithm::Ed25519 => &ring::signature::ED25519,
             _ => bail!(CryptoError::UnsupportedAlgorithm),
@@ -177,7 +177,7 @@ pub struct EdDSASignaturePublicKey {
 }
 
 impl EdDSASignaturePublicKey {
-    pub fn from_raw(alg: SignatureAlgorithm, raw: &[u8]) -> Result<Self, Error> {
+    pub fn from_raw(alg: SignatureAlgorithm, raw: &[u8]) -> Result<Self, CryptoError> {
         let pk = EdDSASignaturePublicKey {
             alg,
             raw: raw.to_vec(),
@@ -185,7 +185,7 @@ impl EdDSASignaturePublicKey {
         Ok(pk)
     }
 
-    pub fn as_raw(&self) -> Result<&[u8], Error> {
+    pub fn as_raw(&self) -> Result<&[u8], CryptoError> {
         Ok(&self.raw)
     }
 }

--- a/proposals/poc/implementation/src/eddsa.rs
+++ b/proposals/poc/implementation/src/eddsa.rs
@@ -10,28 +10,28 @@ use super::signature_keypair::*;
 use super::HandleManagers;
 
 #[derive(Clone, Copy, Debug)]
-pub struct EdDSASignatureOp {
+pub struct EddsaSignatureOp {
     pub alg: SignatureAlgorithm,
 }
 
-impl EdDSASignatureOp {
+impl EddsaSignatureOp {
     pub fn new(alg: SignatureAlgorithm) -> Self {
-        EdDSASignatureOp { alg }
+        EddsaSignatureOp { alg }
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct EdDSASignatureKeyPair {
+pub struct EddsaSignatureKeyPair {
     pub alg: SignatureAlgorithm,
     pub pkcs8: Vec<u8>,
     pub ring_kp: Arc<ring::signature::Ed25519KeyPair>,
 }
 
-impl EdDSASignatureKeyPair {
+impl EddsaSignatureKeyPair {
     pub fn from_pkcs8(alg: SignatureAlgorithm, pkcs8: &[u8]) -> Result<Self, CryptoError> {
         let ring_kp = ring::signature::Ed25519KeyPair::from_pkcs8(pkcs8)
             .map_err(|_| CryptoError::InvalidKey)?;
-        let kp = EdDSASignatureKeyPair {
+        let kp = EddsaSignatureKeyPair {
             alg,
             pkcs8: pkcs8.to_vec(),
             ring_kp: Arc::new(ring_kp),
@@ -55,27 +55,27 @@ impl EdDSASignatureKeyPair {
     }
 }
 
-impl Drop for EdDSASignatureKeyPair {
+impl Drop for EddsaSignatureKeyPair {
     fn drop(&mut self) {
         self.pkcs8.zeroize();
     }
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct EdDSASignatureKeyPairBuilder {
+pub struct EddsaSignatureKeyPairBuilder {
     pub alg: SignatureAlgorithm,
 }
 
-impl EdDSASignatureKeyPairBuilder {
+impl EddsaSignatureKeyPairBuilder {
     pub fn new(alg: SignatureAlgorithm) -> Self {
-        EdDSASignatureKeyPairBuilder { alg }
+        EddsaSignatureKeyPairBuilder { alg }
     }
 
     pub fn generate(&self, handles: &HandleManagers) -> Result<Handle, CryptoError> {
-        let kp = EdDSASignatureKeyPair::generate(self.alg)?;
+        let kp = EddsaSignatureKeyPair::generate(self.alg)?;
         let handle = handles
             .signature_keypair
-            .register(SignatureKeyPair::EdDSA(kp))?;
+            .register(SignatureKeyPair::Eddsa(kp))?;
         Ok(handle)
     }
 
@@ -86,41 +86,41 @@ impl EdDSASignatureKeyPairBuilder {
         encoding: KeyPairEncoding,
     ) -> Result<Handle, CryptoError> {
         match encoding {
-            KeyPairEncoding::PKCS8 => {}
+            KeyPairEncoding::Pkcs8 => {}
             _ => bail!(CryptoError::UnsupportedEncoding),
         };
-        let kp = EdDSASignatureKeyPair::from_pkcs8(self.alg, encoded)?;
+        let kp = EddsaSignatureKeyPair::from_pkcs8(self.alg, encoded)?;
         let handle = handles
             .signature_keypair
-            .register(SignatureKeyPair::EdDSA(kp))?;
+            .register(SignatureKeyPair::Eddsa(kp))?;
         Ok(handle)
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EdDSASignature(pub Vec<u8>);
+pub struct EddsaSignature(pub Vec<u8>);
 
-impl AsRef<[u8]> for EdDSASignature {
+impl AsRef<[u8]> for EddsaSignature {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl EdDSASignature {
+impl EddsaSignature {
     pub fn new(encoded: Vec<u8>) -> Self {
-        EdDSASignature(encoded)
+        EddsaSignature(encoded)
     }
 }
 
 #[derive(Debug)]
-pub struct EdDSASignatureState {
-    pub kp: EdDSASignatureKeyPair,
+pub struct EddsaSignatureState {
+    pub kp: EddsaSignatureKeyPair,
     pub input: Mutex<Vec<u8>>,
 }
 
-impl EdDSASignatureState {
-    pub fn new(kp: EdDSASignatureKeyPair) -> Self {
-        EdDSASignatureState {
+impl EddsaSignatureState {
+    pub fn new(kp: EddsaSignatureKeyPair) -> Self {
+        EddsaSignatureState {
             kp,
             input: Mutex::new(vec![]),
         }
@@ -131,23 +131,23 @@ impl EdDSASignatureState {
         Ok(())
     }
 
-    pub fn sign(&self) -> Result<EdDSASignature, CryptoError> {
+    pub fn sign(&self) -> Result<EddsaSignature, CryptoError> {
         let input = self.input.lock();
         let signature_u8 = self.kp.ring_kp.sign(&input).as_ref().to_vec();
-        let signature = EdDSASignature(signature_u8);
+        let signature = EddsaSignature(signature_u8);
         Ok(signature)
     }
 }
 
 #[derive(Debug)]
-pub struct EdDSASignatureVerificationState {
-    pub pk: EdDSASignaturePublicKey,
+pub struct EddsaSignatureVerificationState {
+    pub pk: EddsaSignaturePublicKey,
     pub input: Mutex<Vec<u8>>,
 }
 
-impl EdDSASignatureVerificationState {
-    pub fn new(pk: EdDSASignaturePublicKey) -> Self {
-        EdDSASignatureVerificationState {
+impl EddsaSignatureVerificationState {
+    pub fn new(pk: EddsaSignaturePublicKey) -> Self {
+        EddsaSignatureVerificationState {
             pk,
             input: Mutex::new(vec![]),
         }
@@ -158,7 +158,7 @@ impl EdDSASignatureVerificationState {
         Ok(())
     }
 
-    pub fn verify(&self, signature: &EdDSASignature) -> Result<(), CryptoError> {
+    pub fn verify(&self, signature: &EddsaSignature) -> Result<(), CryptoError> {
         let ring_alg = match self.pk.alg {
             SignatureAlgorithm::Ed25519 => &ring::signature::ED25519,
             _ => bail!(CryptoError::UnsupportedAlgorithm),
@@ -171,14 +171,14 @@ impl EdDSASignatureVerificationState {
     }
 }
 #[derive(Clone, Debug)]
-pub struct EdDSASignaturePublicKey {
+pub struct EddsaSignaturePublicKey {
     pub alg: SignatureAlgorithm,
     pub raw: Vec<u8>,
 }
 
-impl EdDSASignaturePublicKey {
+impl EddsaSignaturePublicKey {
     pub fn from_raw(alg: SignatureAlgorithm, raw: &[u8]) -> Result<Self, CryptoError> {
-        let pk = EdDSASignaturePublicKey {
+        let pk = EddsaSignaturePublicKey {
             alg,
             raw: raw.to_vec(),
         };

--- a/proposals/poc/implementation/src/handles.rs
+++ b/proposals/poc/implementation/src/handles.rs
@@ -22,15 +22,15 @@ impl<HandleType: Clone + Sync> HandlesManager<HandleType> {
         }
     }
 
-    pub fn close(&self, handle: Handle) -> Result<(), Error> {
+    pub fn close(&self, handle: Handle) -> Result<(), CryptoError> {
         self.inner.lock().close(handle)
     }
 
-    pub fn register(&self, op: HandleType) -> Result<Handle, Error> {
+    pub fn register(&self, op: HandleType) -> Result<Handle, CryptoError> {
         self.inner.lock().register(op)
     }
 
-    pub fn get(&self, handle: Handle) -> Result<HandleType, Error> {
+    pub fn get(&self, handle: Handle) -> Result<HandleType, CryptoError> {
         self.inner.lock().get(handle).map(|x| x.clone())
     }
 }
@@ -44,7 +44,7 @@ impl<HandleType: Clone + Sync> HandlesManagerInner<HandleType> {
         }
     }
 
-    pub fn close(&mut self, handle: Handle) -> Result<(), Error> {
+    pub fn close(&mut self, handle: Handle) -> Result<(), CryptoError> {
         self.map.remove(&handle).ok_or(CryptoError::Closed)?;
         Ok(())
     }
@@ -53,7 +53,7 @@ impl<HandleType: Clone + Sync> HandlesManagerInner<HandleType> {
         ((handle.wrapping_add(1) << 8) | (self.type_id as Handle)).rotate_right(8)
     }
 
-    pub fn register(&mut self, op: HandleType) -> Result<Handle, Error> {
+    pub fn register(&mut self, op: HandleType) -> Result<Handle, CryptoError> {
         let mut handle = self.next_handle(self.last_handle);
         loop {
             if !self.map.contains_key(&handle) {
@@ -70,7 +70,7 @@ impl<HandleType: Clone + Sync> HandlesManagerInner<HandleType> {
         Ok(handle)
     }
 
-    pub fn get(&mut self, handle: Handle) -> Result<&HandleType, Error> {
+    pub fn get(&mut self, handle: Handle) -> Result<&HandleType, CryptoError> {
         let op = self.map.get(&handle).ok_or(CryptoError::InvalidHandle)?;
         Ok(op)
     }

--- a/proposals/poc/implementation/src/lib.rs
+++ b/proposals/poc/implementation/src/lib.rs
@@ -25,11 +25,11 @@ pub use signature_publickey::PublicKeyEncoding;
 #[allow(unused)]
 static REBUILD_IF_WITX_FILE_IS_UPDATED: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
-    "/../witx/wasi_ephemeral_crypto.witx"
+    "/../witx/proposal_signatures.witx"
 ));
 
 wiggle::from_witx!({
-    witx: ["../witx/wasi_ephemeral_crypto.witx"],
+    witx: ["../witx/proposal_signatures.witx"],
     ctx: WasiCryptoCtx
 });
 

--- a/proposals/poc/implementation/src/lib.rs
+++ b/proposals/poc/implementation/src/lib.rs
@@ -25,11 +25,11 @@ pub use signature_publickey::PublicKeyEncoding;
 #[allow(unused)]
 static REBUILD_IF_WITX_FILE_IS_UPDATED: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
-    "/../witx/proposal_signatures.witx"
+    "/../witx/wasi_ephemeral_crypto.witx"
 ));
 
 wiggle::from_witx!({
-    witx: ["../witx/proposal_signatures.witx"],
+    witx: ["../witx/wasi_ephemeral_crypto.witx"],
     ctx: WasiCryptoCtx
 });
 

--- a/proposals/poc/implementation/src/lib.rs
+++ b/proposals/poc/implementation/src/lib.rs
@@ -16,11 +16,22 @@ use signature_keypair::*;
 use signature_op::*;
 use signature_publickey::*;
 
-pub use error::{CryptoError, WasiCryptoError};
+pub use error::CryptoError;
 pub use handles::Handle;
 pub use signature::SignatureEncoding;
 pub use signature_keypair::{KeyPairEncoding, Version};
 pub use signature_publickey::PublicKeyEncoding;
+
+#[allow(unused)]
+static REBUILD_IF_WITX_FILE_IS_UPDATED: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../witx/wasi_ephemeral_crypto.witx"
+));
+
+wiggle::from_witx!({
+    witx: ["../witx/wasi_ephemeral_crypto.witx"],
+    ctx: WasiCryptoCtx
+});
 
 pub struct HandleManagers {
     pub signature_op: HandlesManager<SignatureOp>,
@@ -33,13 +44,17 @@ pub struct HandleManagers {
     pub array_output: HandlesManager<ArrayOutput>,
 }
 
-pub struct WasiCryptoCtx {
+pub struct CryptoCtx {
     pub(crate) handles: HandleManagers,
 }
 
-impl WasiCryptoCtx {
+pub struct WasiCryptoCtx {
+    ctx: CryptoCtx,
+}
+
+impl CryptoCtx {
     pub fn new() -> Self {
-        WasiCryptoCtx {
+        CryptoCtx {
             handles: HandleManagers {
                 array_output: HandlesManager::new(0x00),
                 signature_op: HandlesManager::new(0x01),
@@ -54,9 +69,17 @@ impl WasiCryptoCtx {
     }
 }
 
+impl WasiCryptoCtx {
+    pub fn new() -> Self {
+        WasiCryptoCtx {
+            ctx: CryptoCtx::new(),
+        }
+    }
+}
+
 #[test]
 fn test_signatures() {
-    let ctx = WasiCryptoCtx::new();
+    let ctx = CryptoCtx::new();
     let op_handle = ctx.signature_op_open("ECDSA_P256_SHA256").unwrap();
     let kp_builder_handle = ctx.signature_keypair_builder_open(op_handle).unwrap();
     let kp_handle = ctx.signature_keypair_generate(kp_builder_handle).unwrap();

--- a/proposals/poc/implementation/src/rsa.rs
+++ b/proposals/poc/implementation/src/rsa.rs
@@ -34,7 +34,7 @@ impl Drop for RSASignatureKeyPair {
 }
 
 impl RSASignatureKeyPair {
-    pub fn from_pkcs8(alg: SignatureAlgorithm, pkcs8: &[u8]) -> Result<Self, Error> {
+    pub fn from_pkcs8(alg: SignatureAlgorithm, pkcs8: &[u8]) -> Result<Self, CryptoError> {
         let ring_kp =
             ring::signature::RsaKeyPair::from_pkcs8(pkcs8).map_err(|_| CryptoError::InvalidKey)?;
         let kp = RSASignatureKeyPair {
@@ -45,12 +45,12 @@ impl RSASignatureKeyPair {
         Ok(kp)
     }
 
-    pub fn as_pkcs8(&self) -> Result<&[u8], Error> {
+    pub fn as_pkcs8(&self) -> Result<&[u8], CryptoError> {
         Ok(&self.pkcs8)
     }
 
     #[allow(dead_code)]
-    pub fn generate(_alg: SignatureAlgorithm) -> Result<Self, Error> {
+    pub fn generate(_alg: SignatureAlgorithm) -> Result<Self, CryptoError> {
         bail!(CryptoError::NotImplemented)
     }
 
@@ -69,7 +69,7 @@ impl RSASignatureKeyPairBuilder {
         RSASignatureKeyPairBuilder { alg }
     }
 
-    pub fn generate(&self, _handles: &HandleManagers) -> Result<Handle, Error> {
+    pub fn generate(&self, _handles: &HandleManagers) -> Result<Handle, CryptoError> {
         bail!(CryptoError::NotImplemented)
     }
 
@@ -78,7 +78,7 @@ impl RSASignatureKeyPairBuilder {
         handles: &HandleManagers,
         encoded: &[u8],
         encoding: KeyPairEncoding,
-    ) -> Result<Handle, Error> {
+    ) -> Result<Handle, CryptoError> {
         match encoding {
             KeyPairEncoding::PKCS8 => {}
             _ => bail!(CryptoError::UnsupportedEncoding),
@@ -119,12 +119,12 @@ impl RSASignatureState {
         }
     }
 
-    pub fn update(&self, input: &[u8]) -> Result<(), Error> {
+    pub fn update(&self, input: &[u8]) -> Result<(), CryptoError> {
         self.input.lock().extend_from_slice(input);
         Ok(())
     }
 
-    pub fn sign(&self) -> Result<RSASignature, Error> {
+    pub fn sign(&self) -> Result<RSASignature, CryptoError> {
         let rng = ring::rand::SystemRandom::new();
         let input = self.input.lock();
         let mut signature_u8 = vec![];
@@ -158,12 +158,12 @@ impl RSASignatureVerificationState {
         }
     }
 
-    pub fn update(&self, input: &[u8]) -> Result<(), Error> {
+    pub fn update(&self, input: &[u8]) -> Result<(), CryptoError> {
         self.input.lock().extend_from_slice(input);
         Ok(())
     }
 
-    pub fn verify(&self, signature: &RSASignature) -> Result<(), Error> {
+    pub fn verify(&self, signature: &RSASignature) -> Result<(), CryptoError> {
         let ring_alg = match self.pk.alg {
             SignatureAlgorithm::RSA_PKCS1_2048_8192_SHA256 => {
                 &ring::signature::RSA_PKCS1_2048_8192_SHA256
@@ -194,7 +194,7 @@ pub struct RSASignaturePublicKey {
 }
 
 impl RSASignaturePublicKey {
-    pub fn from_raw(alg: SignatureAlgorithm, raw: &[u8]) -> Result<Self, Error> {
+    pub fn from_raw(alg: SignatureAlgorithm, raw: &[u8]) -> Result<Self, CryptoError> {
         let pk = RSASignaturePublicKey {
             alg,
             raw: raw.to_vec(),
@@ -202,7 +202,7 @@ impl RSASignaturePublicKey {
         Ok(pk)
     }
 
-    pub fn as_raw(&self) -> Result<&[u8], Error> {
+    pub fn as_raw(&self) -> Result<&[u8], CryptoError> {
         Ok(&self.raw)
     }
 }

--- a/proposals/poc/implementation/src/rsa.rs
+++ b/proposals/poc/implementation/src/rsa.rs
@@ -10,34 +10,34 @@ use super::signature_keypair::*;
 use super::HandleManagers;
 
 #[derive(Clone, Copy, Debug)]
-pub struct RSASignatureOp {
+pub struct RsaSignatureOp {
     pub alg: SignatureAlgorithm,
 }
 
-impl RSASignatureOp {
+impl RsaSignatureOp {
     pub fn new(alg: SignatureAlgorithm) -> Self {
-        RSASignatureOp { alg }
+        RsaSignatureOp { alg }
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct RSASignatureKeyPair {
+pub struct RsaSignatureKeyPair {
     pub alg: SignatureAlgorithm,
     pub pkcs8: Vec<u8>,
     pub ring_kp: Arc<ring::signature::RsaKeyPair>,
 }
 
-impl Drop for RSASignatureKeyPair {
+impl Drop for RsaSignatureKeyPair {
     fn drop(&mut self) {
         self.pkcs8.zeroize();
     }
 }
 
-impl RSASignatureKeyPair {
+impl RsaSignatureKeyPair {
     pub fn from_pkcs8(alg: SignatureAlgorithm, pkcs8: &[u8]) -> Result<Self, CryptoError> {
         let ring_kp =
             ring::signature::RsaKeyPair::from_pkcs8(pkcs8).map_err(|_| CryptoError::InvalidKey)?;
-        let kp = RSASignatureKeyPair {
+        let kp = RsaSignatureKeyPair {
             alg,
             pkcs8: pkcs8.to_vec(),
             ring_kp: Arc::new(ring_kp),
@@ -60,13 +60,13 @@ impl RSASignatureKeyPair {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct RSASignatureKeyPairBuilder {
+pub struct RsaSignatureKeyPairBuilder {
     pub alg: SignatureAlgorithm,
 }
 
-impl RSASignatureKeyPairBuilder {
+impl RsaSignatureKeyPairBuilder {
     pub fn new(alg: SignatureAlgorithm) -> Self {
-        RSASignatureKeyPairBuilder { alg }
+        RsaSignatureKeyPairBuilder { alg }
     }
 
     pub fn generate(&self, _handles: &HandleManagers) -> Result<Handle, CryptoError> {
@@ -80,40 +80,40 @@ impl RSASignatureKeyPairBuilder {
         encoding: KeyPairEncoding,
     ) -> Result<Handle, CryptoError> {
         match encoding {
-            KeyPairEncoding::PKCS8 => {}
+            KeyPairEncoding::Pkcs8 => {}
             _ => bail!(CryptoError::UnsupportedEncoding),
         };
-        let kp = RSASignatureKeyPair::from_pkcs8(self.alg, encoded)?;
+        let kp = RsaSignatureKeyPair::from_pkcs8(self.alg, encoded)?;
         let handle = handles
             .signature_keypair
-            .register(SignatureKeyPair::RSA(kp))?;
+            .register(SignatureKeyPair::Rsa(kp))?;
         Ok(handle)
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RSASignature(pub Vec<u8>);
+pub struct RsaSignature(pub Vec<u8>);
 
-impl AsRef<[u8]> for RSASignature {
+impl AsRef<[u8]> for RsaSignature {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl RSASignature {
+impl RsaSignature {
     pub fn new(encoded: Vec<u8>) -> Self {
-        RSASignature(encoded)
+        RsaSignature(encoded)
     }
 }
 #[derive(Debug)]
-pub struct RSASignatureState {
-    pub kp: RSASignatureKeyPair,
+pub struct RsaSignatureState {
+    pub kp: RsaSignatureKeyPair,
     pub input: Mutex<Vec<u8>>,
 }
 
-impl RSASignatureState {
-    pub fn new(kp: RSASignatureKeyPair) -> Self {
-        RSASignatureState {
+impl RsaSignatureState {
+    pub fn new(kp: RsaSignatureKeyPair) -> Self {
+        RsaSignatureState {
             kp,
             input: Mutex::new(vec![]),
         }
@@ -124,7 +124,7 @@ impl RSASignatureState {
         Ok(())
     }
 
-    pub fn sign(&self) -> Result<RSASignature, CryptoError> {
+    pub fn sign(&self) -> Result<RsaSignature, CryptoError> {
         let rng = ring::rand::SystemRandom::new();
         let input = self.input.lock();
         let mut signature_u8 = vec![];
@@ -139,20 +139,20 @@ impl RSASignatureState {
             .ring_kp
             .sign(padding_alg, &rng, &input, &mut signature_u8)
             .map_err(|_| CryptoError::AlgorithmFailure)?;
-        let signature = RSASignature(signature_u8);
+        let signature = RsaSignature(signature_u8);
         Ok(signature)
     }
 }
 
 #[derive(Debug)]
-pub struct RSASignatureVerificationState {
-    pub pk: RSASignaturePublicKey,
+pub struct RsaSignatureVerificationState {
+    pub pk: RsaSignaturePublicKey,
     pub input: Mutex<Vec<u8>>,
 }
 
-impl RSASignatureVerificationState {
-    pub fn new(pk: RSASignaturePublicKey) -> Self {
-        RSASignatureVerificationState {
+impl RsaSignatureVerificationState {
+    pub fn new(pk: RsaSignaturePublicKey) -> Self {
+        RsaSignatureVerificationState {
             pk,
             input: Mutex::new(vec![]),
         }
@@ -163,7 +163,7 @@ impl RSASignatureVerificationState {
         Ok(())
     }
 
-    pub fn verify(&self, signature: &RSASignature) -> Result<(), CryptoError> {
+    pub fn verify(&self, signature: &RsaSignature) -> Result<(), CryptoError> {
         let ring_alg = match self.pk.alg {
             SignatureAlgorithm::RSA_PKCS1_2048_8192_SHA256 => {
                 &ring::signature::RSA_PKCS1_2048_8192_SHA256
@@ -188,14 +188,14 @@ impl RSASignatureVerificationState {
 }
 
 #[derive(Clone, Debug)]
-pub struct RSASignaturePublicKey {
+pub struct RsaSignaturePublicKey {
     pub alg: SignatureAlgorithm,
     pub raw: Vec<u8>,
 }
 
-impl RSASignaturePublicKey {
+impl RsaSignaturePublicKey {
     pub fn from_raw(alg: SignatureAlgorithm, raw: &[u8]) -> Result<Self, CryptoError> {
-        let pk = RSASignaturePublicKey {
+        let pk = RsaSignaturePublicKey {
             alg,
             raw: raw.to_vec(),
         };

--- a/proposals/poc/implementation/src/signature_keypair.rs
+++ b/proposals/poc/implementation/src/signature_keypair.rs
@@ -6,7 +6,8 @@ use super::handles::*;
 use super::rsa::*;
 use super::signature_op::*;
 use super::signature_publickey::*;
-use super::{HandleManagers, WasiCryptoCtx};
+use super::types as guest_types;
+use super::{CryptoCtx, HandleManagers, WasiCryptoCtx};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Version(u64);
@@ -17,13 +18,35 @@ impl Version {
     pub const ALL: Version = Version(0xff00_0000_0000_0000);
 }
 
+impl From<guest_types::Version> for Version {
+    fn from(version: guest_types::Version) -> Self {
+        Version(version.into())
+    }
+}
+
+impl From<Version> for guest_types::Version {
+    fn from(version: Version) -> Self {
+        version.into()
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(u16)]
 pub enum KeyPairEncoding {
-    Raw = 1,
-    PKCS8 = 2,
-    DER = 3,
-    PEM = 4,
+    Raw,
+    PKCS8,
+    DER,
+    PEM,
+}
+
+impl From<guest_types::KeypairEncoding> for KeyPairEncoding {
+    fn from(encoding: guest_types::KeypairEncoding) -> Self {
+        match encoding {
+            guest_types::KeypairEncoding::Raw => KeyPairEncoding::Raw,
+            guest_types::KeypairEncoding::Pkcs8 => KeyPairEncoding::PKCS8,
+            guest_types::KeypairEncoding::Der => KeyPairEncoding::DER,
+            guest_types::KeypairEncoding::Pem => KeyPairEncoding::PEM,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -34,7 +57,7 @@ pub enum SignatureKeyPair {
 }
 
 impl SignatureKeyPair {
-    fn export(&self, encoding: KeyPairEncoding) -> Result<Vec<u8>, Error> {
+    fn export(&self, encoding: KeyPairEncoding) -> Result<Vec<u8>, CryptoError> {
         let encoded = match encoding {
             KeyPairEncoding::PKCS8 => match self {
                 SignatureKeyPair::ECDSA(kp) => kp.as_pkcs8()?.to_vec(),
@@ -46,7 +69,10 @@ impl SignatureKeyPair {
         Ok(encoded)
     }
 
-    fn generate(handles: &HandleManagers, kp_builder_handle: Handle) -> Result<Handle, Error> {
+    fn generate(
+        handles: &HandleManagers,
+        kp_builder_handle: Handle,
+    ) -> Result<Handle, CryptoError> {
         let kp_builder = handles.signature_keypair_builder.get(kp_builder_handle)?;
         let handle = match kp_builder {
             SignatureKeyPairBuilder::ECDSA(kp_builder) => kp_builder.generate(handles)?,
@@ -61,7 +87,7 @@ impl SignatureKeyPair {
         kp_builder_handle: Handle,
         encoded: &[u8],
         encoding: KeyPairEncoding,
-    ) -> Result<Handle, Error> {
+    ) -> Result<Handle, CryptoError> {
         let kp_builder = handles.signature_keypair_builder.get(kp_builder_handle)?;
         let handle = match kp_builder {
             SignatureKeyPairBuilder::ECDSA(kp_builder) => {
@@ -77,7 +103,7 @@ impl SignatureKeyPair {
         Ok(handle)
     }
 
-    fn public_key(&self, handles: &HandleManagers) -> Result<Handle, Error> {
+    fn public_key(&self, handles: &HandleManagers) -> Result<Handle, CryptoError> {
         let pk = match self {
             SignatureKeyPair::ECDSA(kp) => {
                 let raw_pk = kp.raw_public_key();
@@ -105,7 +131,7 @@ pub enum SignatureKeyPairBuilder {
 }
 
 impl SignatureKeyPairBuilder {
-    fn open(handles: &HandleManagers, op_handle: Handle) -> Result<Handle, Error> {
+    fn open(handles: &HandleManagers, op_handle: Handle) -> Result<Handle, CryptoError> {
         let signature_op = handles.signature_op.get(op_handle)?;
         let kp_builder = match signature_op {
             SignatureOp::ECDSA(_) => SignatureKeyPairBuilder::ECDSA(
@@ -123,16 +149,24 @@ impl SignatureKeyPairBuilder {
     }
 }
 
-impl WasiCryptoCtx {
-    pub fn signature_keypair_builder_open(&self, op_handle: Handle) -> Result<Handle, Error> {
+impl CryptoCtx {
+    pub fn signature_keypair_builder_open(&self, op_handle: Handle) -> Result<Handle, CryptoError> {
         SignatureKeyPairBuilder::open(&self.handles, op_handle)
     }
 
-    pub fn signature_keypair_builder_close(&self, handle: Handle) -> Result<(), Error> {
-        self.handles.signature_keypair_builder.close(handle)
+    pub fn signature_keypair_builder_close(
+        &self,
+        kp_builder_handle: Handle,
+    ) -> Result<(), CryptoError> {
+        self.handles
+            .signature_keypair_builder
+            .close(kp_builder_handle)
     }
 
-    pub fn signature_keypair_generate(&self, kp_builder_handle: Handle) -> Result<Handle, Error> {
+    pub fn signature_keypair_generate(
+        &self,
+        kp_builder_handle: Handle,
+    ) -> Result<Handle, CryptoError> {
         SignatureKeyPair::generate(&self.handles, kp_builder_handle)
     }
 
@@ -141,7 +175,7 @@ impl WasiCryptoCtx {
         kp_builder_handle: Handle,
         encoded: &[u8],
         encoding: KeyPairEncoding,
-    ) -> Result<Handle, Error> {
+    ) -> Result<Handle, CryptoError> {
         SignatureKeyPair::import(&self.handles, kp_builder_handle, encoded, encoding)
     }
 
@@ -150,11 +184,14 @@ impl WasiCryptoCtx {
         _kp_builder_handle: Handle,
         _kp_id: &[u8],
         _kp_version: Version,
-    ) -> Result<Handle, Error> {
+    ) -> Result<Handle, CryptoError> {
         bail!(CryptoError::UnsupportedFeature)
     }
 
-    pub fn signature_keypair_id(&self, kp_handle: Handle) -> Result<(Handle, Version), Error> {
+    pub fn signature_keypair_id(
+        &self,
+        kp_handle: Handle,
+    ) -> Result<(Vec<u8>, Version), CryptoError> {
         let _kp = self.handles.signature_keypair.get(kp_handle)?;
         bail!(CryptoError::UnsupportedFeature)
     }
@@ -164,7 +201,7 @@ impl WasiCryptoCtx {
         _kp_builder_handle: Handle,
         _kp_id: &[u8],
         _kp_version: Version,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CryptoError> {
         bail!(CryptoError::UnsupportedFeature)
     }
 
@@ -172,20 +209,153 @@ impl WasiCryptoCtx {
         &self,
         kp_handle: Handle,
         encoding: KeyPairEncoding,
-    ) -> Result<Handle, Error> {
+    ) -> Result<Handle, CryptoError> {
         let kp = self.handles.signature_keypair.get(kp_handle)?;
         let encoded = kp.export(encoding)?;
         let array_output_handle = ArrayOutput::register(&self.handles, encoded)?;
         Ok(array_output_handle)
     }
 
-    pub fn signature_keypair_publickey(&self, kp_handle: Handle) -> Result<Handle, Error> {
+    pub fn signature_keypair_publickey(&self, kp_handle: Handle) -> Result<Handle, CryptoError> {
         let kp = self.handles.signature_keypair.get(kp_handle)?;
         let handle = kp.public_key(&self.handles)?;
         Ok(handle)
     }
 
-    pub fn signature_keypair_close(&self, handle: Handle) -> Result<(), Error> {
-        self.handles.signature_keypair.close(handle)
+    pub fn signature_keypair_close(&self, kp_handle: Handle) -> Result<(), CryptoError> {
+        self.handles.signature_keypair.close(kp_handle)
+    }
+}
+
+impl WasiCryptoCtx {
+    pub fn signature_keypair_builder_open(
+        &self,
+        op_handle: guest_types::SignatureOp,
+    ) -> Result<guest_types::SignatureKeypairBuilder, CryptoError> {
+        Ok(self
+            .ctx
+            .signature_keypair_builder_open(op_handle.into())?
+            .into())
+    }
+
+    pub fn signature_keypair_builder_close(
+        &self,
+        kp_builder_handle: guest_types::SignatureKeypairBuilder,
+    ) -> Result<(), CryptoError> {
+        self.ctx
+            .signature_keypair_builder_close(kp_builder_handle.into())
+    }
+
+    pub fn signature_keypair_generate(
+        &self,
+        kp_builder_handle: guest_types::SignatureKeypairBuilder,
+    ) -> Result<guest_types::SignatureKeypair, CryptoError> {
+        Ok(self
+            .ctx
+            .signature_keypair_generate(kp_builder_handle.into())?
+            .into())
+    }
+
+    pub fn signature_keypair_import(
+        &self,
+        kp_builder_handle: guest_types::SignatureKeypairBuilder,
+        encoded_ptr: wiggle_runtime::GuestPtr<'_, u8>,
+        encoded_len: guest_types::Size,
+        encoding: guest_types::KeypairEncoding,
+    ) -> Result<guest_types::SignatureKeypair, CryptoError> {
+        let mut guest_borrow = wiggle_runtime::GuestBorrows::new();
+        let encoded: &[u8] = unsafe {
+            &*encoded_ptr
+                .as_array(encoded_len as _)
+                .as_raw(&mut guest_borrow)?
+        };
+        Ok(self
+            .ctx
+            .signature_keypair_import(kp_builder_handle.into(), encoded, encoding.into())?
+            .into())
+    }
+
+    pub fn signature_keypair_from_id(
+        &self,
+        kp_builder_handle: guest_types::SignatureKeypairBuilder,
+        kp_id_ptr: wiggle_runtime::GuestPtr<'_, u8>,
+        kp_id_len: guest_types::Size,
+        kp_version: guest_types::Version,
+    ) -> Result<guest_types::SignatureKeypair, CryptoError> {
+        let mut guest_borrow = wiggle_runtime::GuestBorrows::new();
+        let kp_id: &[u8] = unsafe {
+            &*kp_id_ptr
+                .as_array(kp_id_len as _)
+                .as_raw(&mut guest_borrow)?
+        };
+        Ok(self
+            .ctx
+            .signature_keypair_from_id(kp_builder_handle.into(), kp_id, kp_version.into())?
+            .into())
+    }
+
+    pub fn signature_keypair_id(
+        &self,
+        kp_handle: guest_types::SignatureKeypair,
+        kp_id_ptr: wiggle_runtime::GuestPtr<'_, u8>,
+        kp_id_max_len: guest_types::Size,
+    ) -> Result<(guest_types::Size, guest_types::Version), CryptoError> {
+        let mut guest_borrow = wiggle_runtime::GuestBorrows::new();
+        let kp_id_buf: &mut [u8] = unsafe {
+            &mut *kp_id_ptr
+                .as_array(kp_id_max_len as _)
+                .as_raw(&mut guest_borrow)?
+        };
+        let (kp_id, version) = self.ctx.signature_keypair_id(kp_handle.into())?;
+        ensure!(kp_id.len() <= kp_id_buf.len(), CryptoError::Overflow);
+        kp_id_buf.copy_from_slice(&kp_id);
+        Ok((kp_id.len(), version.into()))
+    }
+
+    pub fn signature_keypair_invalidate(
+        &self,
+        kp_builder_handle: guest_types::SignatureKeypairBuilder,
+        kp_id_ptr: wiggle_runtime::GuestPtr<'_, u8>,
+        kp_id_len: guest_types::Size,
+        kp_version: guest_types::Version,
+    ) -> Result<(), CryptoError> {
+        let mut guest_borrow = wiggle_runtime::GuestBorrows::new();
+        let kp_id: &[u8] = unsafe {
+            &*kp_id_ptr
+                .as_array(kp_id_len as _)
+                .as_raw(&mut guest_borrow)?
+        };
+        Ok(self
+            .ctx
+            .signature_keypair_invalidate(kp_builder_handle.into(), kp_id, kp_version.into())?
+            .into())
+    }
+
+    pub fn signature_keypair_export(
+        &self,
+        kp_handle: guest_types::SignatureKeypair,
+        encoding: guest_types::KeypairEncoding,
+    ) -> Result<guest_types::ArrayOutput, CryptoError> {
+        Ok(self
+            .ctx
+            .signature_keypair_export(kp_handle.into(), encoding.into())?
+            .into())
+    }
+
+    pub fn signature_keypair_publickey(
+        &self,
+        kp_handle: guest_types::SignatureKeypair,
+    ) -> Result<guest_types::SignaturePublickey, CryptoError> {
+        Ok(self
+            .ctx
+            .signature_keypair_publickey(kp_handle.into())?
+            .into())
+    }
+
+    pub fn signature_keypair_close(
+        &self,
+        kp_handle: guest_types::SignatureKeypair,
+    ) -> Result<(), CryptoError> {
+        Ok(self.ctx.signature_keypair_close(kp_handle.into())?.into())
     }
 }

--- a/proposals/poc/implementation/src/signature_op.rs
+++ b/proposals/poc/implementation/src/signature_op.rs
@@ -9,39 +9,39 @@ use super::{CryptoCtx, HandleManagers, WasiCryptoCtx};
 
 #[derive(Clone, Copy, Debug)]
 pub enum SignatureOp {
-    ECDSA(ECDSASignatureOp),
-    EdDSA(EdDSASignatureOp),
-    RSA(RSASignatureOp),
+    Ecdsa(EcdsaSignatureOp),
+    Eddsa(EddsaSignatureOp),
+    Rsa(RsaSignatureOp),
 }
 
 impl SignatureOp {
     pub fn alg(self) -> SignatureAlgorithm {
         match self {
-            SignatureOp::ECDSA(op) => op.alg,
-            SignatureOp::EdDSA(op) => op.alg,
-            SignatureOp::RSA(op) => op.alg,
+            SignatureOp::Ecdsa(op) => op.alg,
+            SignatureOp::Eddsa(op) => op.alg,
+            SignatureOp::Rsa(op) => op.alg,
         }
     }
 
     fn open(handles: &HandleManagers, alg_str: &str) -> Result<Handle, CryptoError> {
         let signature_op = match alg_str {
             "ECDSA_P256_SHA256" => {
-                SignatureOp::ECDSA(ECDSASignatureOp::new(SignatureAlgorithm::ECDSA_P256_SHA256))
+                SignatureOp::Ecdsa(EcdsaSignatureOp::new(SignatureAlgorithm::ECDSA_P256_SHA256))
             }
             "ECDSA_P384_SHA384" => {
-                SignatureOp::ECDSA(ECDSASignatureOp::new(SignatureAlgorithm::ECDSA_P384_SHA384))
+                SignatureOp::Ecdsa(EcdsaSignatureOp::new(SignatureAlgorithm::ECDSA_P384_SHA384))
             }
-            "Ed25519" => SignatureOp::EdDSA(EdDSASignatureOp::new(SignatureAlgorithm::Ed25519)),
-            "RSA_PKCS1_2048_8192_SHA256" => SignatureOp::RSA(RSASignatureOp::new(
+            "Ed25519" => SignatureOp::Eddsa(EddsaSignatureOp::new(SignatureAlgorithm::Ed25519)),
+            "RSA_PKCS1_2048_8192_SHA256" => SignatureOp::Rsa(RsaSignatureOp::new(
                 SignatureAlgorithm::RSA_PKCS1_2048_8192_SHA256,
             )),
-            "RSA_PKCS1_2048_8192_SHA384" => SignatureOp::RSA(RSASignatureOp::new(
+            "RSA_PKCS1_2048_8192_SHA384" => SignatureOp::Rsa(RsaSignatureOp::new(
                 SignatureAlgorithm::RSA_PKCS1_2048_8192_SHA384,
             )),
-            "RSA_PKCS1_2048_8192_SHA512" => SignatureOp::RSA(RSASignatureOp::new(
+            "RSA_PKCS1_2048_8192_SHA512" => SignatureOp::Rsa(RsaSignatureOp::new(
                 SignatureAlgorithm::RSA_PKCS1_2048_8192_SHA512,
             )),
-            "RSA_PKCS1_3072_8192_SHA384" => SignatureOp::RSA(RSASignatureOp::new(
+            "RSA_PKCS1_3072_8192_SHA384" => SignatureOp::Rsa(RsaSignatureOp::new(
                 SignatureAlgorithm::RSA_PKCS1_3072_8192_SHA384,
             )),
             _ => bail!(CryptoError::UnsupportedAlgorithm),

--- a/proposals/poc/implementation/src/signature_op.rs
+++ b/proposals/poc/implementation/src/signature_op.rs
@@ -4,7 +4,8 @@ use super::error::*;
 use super::handles::*;
 use super::rsa::*;
 use super::signature::*;
-use super::{HandleManagers, WasiCryptoCtx};
+use super::types as guest_types;
+use super::{CryptoCtx, HandleManagers, WasiCryptoCtx};
 
 #[derive(Clone, Copy, Debug)]
 pub enum SignatureOp {
@@ -22,7 +23,7 @@ impl SignatureOp {
         }
     }
 
-    fn open(handles: &HandleManagers, alg_str: &str) -> Result<Handle, Error> {
+    fn open(handles: &HandleManagers, alg_str: &str) -> Result<Handle, CryptoError> {
         let signature_op = match alg_str {
             "ECDSA_P256_SHA256" => {
                 SignatureOp::ECDSA(ECDSASignatureOp::new(SignatureAlgorithm::ECDSA_P256_SHA256))
@@ -50,12 +51,30 @@ impl SignatureOp {
     }
 }
 
-impl WasiCryptoCtx {
-    pub fn signature_op_open(&self, alg_str: &str) -> Result<Handle, Error> {
+impl CryptoCtx {
+    pub fn signature_op_open(&self, alg_str: &str) -> Result<Handle, CryptoError> {
         SignatureOp::open(&self.handles, alg_str)
     }
 
-    pub fn signature_op_close(&self, handle: Handle) -> Result<(), Error> {
+    pub fn signature_op_close(&self, handle: Handle) -> Result<(), CryptoError> {
         self.handles.signature_op.close(handle)
+    }
+}
+
+impl WasiCryptoCtx {
+    pub fn signature_op_open(
+        &self,
+        alg_str: &wiggle_runtime::GuestPtr<'_, str>,
+    ) -> Result<guest_types::SignatureOp, CryptoError> {
+        let mut guest_borrow = wiggle_runtime::GuestBorrows::new();
+        let alg_str: &str = unsafe { &*alg_str.as_raw(&mut guest_borrow)? };
+        Ok(self.ctx.signature_op_open(alg_str)?.into())
+    }
+
+    pub fn signature_op_close(
+        &self,
+        op_handle: guest_types::SignatureOp,
+    ) -> Result<(), CryptoError> {
+        self.ctx.signature_op_close(op_handle.into())
     }
 }

--- a/proposals/poc/implementation/src/signature_publickey.rs
+++ b/proposals/poc/implementation/src/signature_publickey.rs
@@ -14,8 +14,8 @@ pub enum PublicKeyEncoding {
     Hex,
     Base64Original,
     Base64OriginalNoPadding,
-    Base64URLSafe,
-    Base64URLSafeNoPadding,
+    Base64UrlSafe,
+    Base64UrlSafeNoPadding,
 }
 
 impl From<guest_types::PublickeyEncoding> for PublicKeyEncoding {
@@ -24,12 +24,12 @@ impl From<guest_types::PublickeyEncoding> for PublicKeyEncoding {
             guest_types::PublickeyEncoding::Raw => PublicKeyEncoding::Raw,
             guest_types::PublickeyEncoding::Hex => PublicKeyEncoding::Hex,
             guest_types::PublickeyEncoding::Base64Original => PublicKeyEncoding::Base64Original,
-            guest_types::PublickeyEncoding::Base64OriginalNopadding => {
+            guest_types::PublickeyEncoding::Base64OriginalNoPadding => {
                 PublicKeyEncoding::Base64OriginalNoPadding
             }
-            guest_types::PublickeyEncoding::Base64Urlsafe => PublicKeyEncoding::Base64URLSafe,
-            guest_types::PublickeyEncoding::Base64UrlsafeNopadding => {
-                PublicKeyEncoding::Base64URLSafeNoPadding
+            guest_types::PublickeyEncoding::Base64UrlSafe => PublicKeyEncoding::Base64UrlSafe,
+            guest_types::PublickeyEncoding::Base64UrlSafeNoPadding => {
+                PublicKeyEncoding::Base64UrlSafeNoPadding
             }
         }
     }
@@ -37,9 +37,9 @@ impl From<guest_types::PublickeyEncoding> for PublicKeyEncoding {
 
 #[derive(Clone, Debug)]
 pub enum SignaturePublicKey {
-    ECDSA(ECDSASignaturePublicKey),
-    EdDSA(EdDSASignaturePublicKey),
-    RSA(RSASignaturePublicKey),
+    Ecdsa(EcdsaSignaturePublicKey),
+    Eddsa(EddsaSignaturePublicKey),
+    Rsa(RsaSignaturePublicKey),
 }
 
 impl SignaturePublicKey {
@@ -56,13 +56,13 @@ impl SignaturePublicKey {
         let signature_op = handles.signature_op.get(signature_op)?;
         let pk =
             match signature_op {
-                SignatureOp::ECDSA(_) => SignaturePublicKey::ECDSA(
-                    ECDSASignaturePublicKey::from_raw(signature_op.alg(), encoded)?,
+                SignatureOp::Ecdsa(_) => SignaturePublicKey::Ecdsa(
+                    EcdsaSignaturePublicKey::from_raw(signature_op.alg(), encoded)?,
                 ),
-                SignatureOp::EdDSA(_) => SignaturePublicKey::EdDSA(
-                    EdDSASignaturePublicKey::from_raw(signature_op.alg(), encoded)?,
+                SignatureOp::Eddsa(_) => SignaturePublicKey::Eddsa(
+                    EddsaSignaturePublicKey::from_raw(signature_op.alg(), encoded)?,
                 ),
-                SignatureOp::RSA(_) => SignaturePublicKey::RSA(RSASignaturePublicKey::from_raw(
+                SignatureOp::Rsa(_) => SignaturePublicKey::Rsa(RsaSignaturePublicKey::from_raw(
                     signature_op.alg(),
                     encoded,
                 )?),
@@ -82,9 +82,9 @@ impl SignaturePublicKey {
         }
         let pk = handles.signature_publickey.get(pk)?;
         let raw_pk = match pk {
-            SignaturePublicKey::ECDSA(pk) => pk.as_raw()?.to_vec(),
-            SignaturePublicKey::EdDSA(pk) => pk.as_raw()?.to_vec(),
-            SignaturePublicKey::RSA(pk) => pk.as_raw()?.to_vec(),
+            SignaturePublicKey::Ecdsa(pk) => pk.as_raw()?.to_vec(),
+            SignaturePublicKey::Eddsa(pk) => pk.as_raw()?.to_vec(),
+            SignaturePublicKey::Rsa(pk) => pk.as_raw()?.to_vec(),
         };
         Ok(raw_pk)
     }

--- a/proposals/poc/witx/proposal_signatures.md
+++ b/proposals/poc/witx/proposal_signatures.md
@@ -4,6 +4,8 @@
 ### Variants
 - <a href="#crypto_errno.success" name="crypto_errno.success"></a> `success`
 
+- <a href="#crypto_errno.guest_error" name="crypto_errno.guest_error"></a> `guest_error`
+
 - <a href="#crypto_errno.not_implemented" name="crypto_errno.not_implemented"></a> `not_implemented`
 
 - <a href="#crypto_errno.unsupported_feature" name="crypto_errno.unsupported_feature"></a> `unsupported_feature`
@@ -123,13 +125,15 @@ Perform an operation over all versions of a key.
 
 ---
 
-#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> size`
+#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> (crypto_errno, size)`
 Return the length of an array_output object.
 
 ##### Params
 - <a href="#array_output_len.array_output" name="array_output_len.array_output"></a> `array_output`: [`array_output`](#array_output)
 
 ##### Results
+- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+
 - <a href="#array_output_len.len" name="array_output_len.len"></a> `len`: [`size`](#size)
 
 
@@ -243,7 +247,7 @@ cannot be decoded.
 
 ---
 
-#### <a href="#signature_keypair_id" name="signature_keypair_id"></a> `signature_keypair_id(kp: signature_keypair, kp_id: ConstPointer<u8>, kp_id_max_len: size) -> (crypto_errno, size, version)`
+#### <a href="#signature_keypair_id" name="signature_keypair_id"></a> `signature_keypair_id(kp: signature_keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> (crypto_errno, size, version)`
 [OPTIONAL IMPORT]
 Return the key identifier and version, if these are available
 or $crypto_errno.unsupported_feature if not.
@@ -251,7 +255,7 @@ or $crypto_errno.unsupported_feature if not.
 ##### Params
 - <a href="#signature_keypair_id.kp" name="signature_keypair_id.kp"></a> `kp`: [`signature_keypair`](#signature_keypair)
 
-- <a href="#signature_keypair_id.kp_id" name="signature_keypair_id.kp_id"></a> `kp_id`: `ConstPointer<u8>`
+- <a href="#signature_keypair_id.kp_id" name="signature_keypair_id.kp_id"></a> `kp_id`: `Pointer<u8>`
 
 - <a href="#signature_keypair_id.kp_id_max_len" name="signature_keypair_id.kp_id_max_len"></a> `kp_id_max_len`: [`size`](#size)
 

--- a/proposals/poc/witx/proposal_signatures.md
+++ b/proposals/poc/witx/proposal_signatures.md
@@ -56,11 +56,11 @@
 
 - <a href="#publickey_encoding.base64_original" name="publickey_encoding.base64_original"></a> `base64_original`
 
-- <a href="#publickey_encoding.base64_original_nopadding" name="publickey_encoding.base64_original_nopadding"></a> `base64_original_nopadding`
+- <a href="#publickey_encoding.base64_original_no_padding" name="publickey_encoding.base64_original_no_padding"></a> `base64_original_no_padding`
 
-- <a href="#publickey_encoding.base64_urlsafe" name="publickey_encoding.base64_urlsafe"></a> `base64_urlsafe`
+- <a href="#publickey_encoding.base64_url_safe" name="publickey_encoding.base64_url_safe"></a> `base64_url_safe`
 
-- <a href="#publickey_encoding.base64_urlsafe_nopadding" name="publickey_encoding.base64_urlsafe_nopadding"></a> `base64_urlsafe_nopadding`
+- <a href="#publickey_encoding.base64_url_safe_no_padding" name="publickey_encoding.base64_url_safe_no_padding"></a> `base64_url_safe_no_padding`
 
 ## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: Enum(`u16`)
 
@@ -71,11 +71,11 @@
 
 - <a href="#signature_encoding.base64_original" name="signature_encoding.base64_original"></a> `base64_original`
 
-- <a href="#signature_encoding.base64_original_nopadding" name="signature_encoding.base64_original_nopadding"></a> `base64_original_nopadding`
+- <a href="#signature_encoding.base64_original_no_padding" name="signature_encoding.base64_original_no_padding"></a> `base64_original_no_padding`
 
-- <a href="#signature_encoding.base64_urlsafe" name="signature_encoding.base64_urlsafe"></a> `base64_urlsafe`
+- <a href="#signature_encoding.base64_url_safe" name="signature_encoding.base64_url_safe"></a> `base64_url_safe`
 
-- <a href="#signature_encoding.base64_urlsafe_nopadding" name="signature_encoding.base64_urlsafe_nopadding"></a> `base64_urlsafe_nopadding`
+- <a href="#signature_encoding.base64_url_safe_no_padding" name="signature_encoding.base64_url_safe_no_padding"></a> `base64_url_safe_no_padding`
 
 - <a href="#signature_encoding.der" name="signature_encoding.der"></a> `der`
 

--- a/proposals/poc/witx/proposal_signatures.witx
+++ b/proposals/poc/witx/proposal_signatures.witx
@@ -36,9 +36,9 @@
     $raw
     $hex
     $base64_original
-    $base64_original_nopadding
-    $base64_urlsafe
-    $base64_urlsafe_nopadding
+    $base64_original_no_padding
+    $base64_url_safe
+    $base64_url_safe_no_padding
   )
 )
 
@@ -47,9 +47,9 @@
     $raw
     $hex
     $base64_original
-    $base64_original_nopadding
-    $base64_urlsafe
-    $base64_urlsafe_nopadding
+    $base64_original_no_padding
+    $base64_url_safe
+    $base64_url_safe_no_padding
     $der
   )
 )

--- a/proposals/poc/witx/proposal_signatures.witx
+++ b/proposals/poc/witx/proposal_signatures.witx
@@ -3,6 +3,7 @@
 (typename $crypto_errno
   (enum u16
     $success
+    $guest_error
     $not_implemented
     $unsupported_feature
     $prohibited_operation
@@ -81,6 +82,7 @@
   ;;; Return the length of an array_output object.
   (@interface func (export "array_output_len")
     (param $array_output $array_output)
+    (result $error $crypto_errno)
     (result $len $size)
   )
 
@@ -146,7 +148,7 @@
   ;;; or $crypto_errno.unsupported_feature if not.
   (@interface func (export "signature_keypair_id")
     (param $kp $signature_keypair)
-    (param $kp_id (@witx const_pointer u8))
+    (param $kp_id (@witx pointer u8))
     (param $kp_id_max_len $size)
     (result $error $crypto_errno)
     (result $kp_id_len $size)


### PR DESCRIPTION
This adds the missing pieces to make the signature API available to WebAssembly modules, namely all the machinery to convert data between the host and a guest.

Integration into Lucet and Wasmtime should be pretty straightfoward at that point.

The internal interface is automatically generated by `wiggle` from the `witx` file, so this proves that the implementation matches the definition.

Enforcing both to match at compilation time immediately spotted minor inconsistencies in the `witx` file that this changeset also fixes.
