### PR TITLE
Update witx files for 0.9 witx crate

### DIFF
--- a/witx/proposal_asymmetric_common.md
+++ b/witx/proposal_asymmetric_common.md
@@ -1,12 +1,12 @@
 # Types
-## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: Enum(`u16`)
+## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: `Variant`
 Error codes.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#crypto_errno.success" name="crypto_errno.success"></a> `success`
 Operation succeeded.
 
@@ -151,14 +151,14 @@ This error is returned when trying to build a key pair from a public key and a s
 - <a href="#crypto_errno.expired" name="crypto_errno.expired"></a> `expired`
 A managed key or secret expired and cannot be used any more.
 
-## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: Enum(`u16`)
+## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: `Variant`
 Encoding to use for importing or exporting a key pair.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#keypair_encoding.raw" name="keypair_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -171,14 +171,14 @@ PEM encoding.
 - <a href="#keypair_encoding.local" name="keypair_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: Enum(`u16`)
+## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: `Variant`
 Encoding to use for importing or exporting a public key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#publickey_encoding.raw" name="publickey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -197,14 +197,14 @@ Compressed SEC encoding.
 - <a href="#publickey_encoding.local" name="publickey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: Enum(`u16`)
+## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: `Variant`
 Encoding to use for importing or exporting a secret key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#secretkey_encoding.raw" name="secretkey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -223,52 +223,49 @@ Compressed SEC encoding.
 - <a href="#secretkey_encoding.local" name="secretkey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: Enum(`u16`)
+## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: `Variant`
 Encoding to use for importing or exporting a signature.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#signature_encoding.raw" name="signature_encoding.raw"></a> `raw`
 Raw bytes.
 
 - <a href="#signature_encoding.der" name="signature_encoding.der"></a> `der`
 DER encoding.
 
-## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: Enum(`u16`)
+## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: `Variant`
 An algorithm category.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#algorithm_type.signatures" name="algorithm_type.signatures"></a> `signatures`
 
 - <a href="#algorithm_type.symmetric" name="algorithm_type.symmetric"></a> `symmetric`
 
 - <a href="#algorithm_type.key_exchange" name="algorithm_type.key_exchange"></a> `key_exchange`
 
-## <a href="#version" name="version"></a> `version`: Int(`u64`)
+## <a href="#version" name="version"></a> `version`: `u64`
 Version of a managed key.
 
-A version can be an arbitrary `u64` integer, with the expection of some reserved values.
+A version can be an arbitrary [`u64`](#u64) integer, with the expection of some reserved values.
 
 Size: 8
 
 Alignment: 8
 
-### Consts
+### Constants
 - <a href="#version.unspecified" name="version.unspecified"></a> `unspecified`
-Key doesn't support versioning.
 
 - <a href="#version.latest" name="version.latest"></a> `latest`
-Use the latest version of a key.
 
 - <a href="#version.all" name="version.all"></a> `all`
-Perform an operation over all versions of a key.
 
 ## <a href="#size" name="size"></a> `size`: `usize`
 Size of a value.
@@ -284,7 +281,7 @@ Size: 8
 
 Alignment: 8
 
-## <a href="#array_output" name="array_output"></a> `array_output`
+## <a href="#array_output" name="array_output"></a> `array_output`: `Handle`
 Handle for functions returning output whose size may be large or not known in advance.
 
 An [`array_output`](#array_output) object contains a host-allocated byte array.
@@ -299,7 +296,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#options" name="options"></a> `options`
+## <a href="#options" name="options"></a> `options`: `Handle`
 A set of options.
 
 This type is used to set non-default parameters.
@@ -311,7 +308,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`
+## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`: `Handle`
 A handle to the optional secrets management facilities offered by a host.
 
 This is used to generate, retrieve and invalidate managed keys.
@@ -321,7 +318,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#keypair" name="keypair"></a> `keypair`
+## <a href="#keypair" name="keypair"></a> `keypair`: `Handle`
 A key pair.
 
 Size: 4
@@ -329,7 +326,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_state" name="signature_state"></a> `signature_state`
+## <a href="#signature_state" name="signature_state"></a> `signature_state`: `Handle`
 A state to absorb data to be signed.
 
 After a signature has been computed or verified, the state remains valid for further operations.
@@ -341,7 +338,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature" name="signature"></a> `signature`
+## <a href="#signature" name="signature"></a> `signature`: `Handle`
 A signature.
 
 Size: 4
@@ -349,7 +346,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#publickey" name="publickey"></a> `publickey`
+## <a href="#publickey" name="publickey"></a> `publickey`: `Handle`
 A public key, for key exchange and signature verification.
 
 Size: 4
@@ -357,7 +354,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secretkey" name="secretkey"></a> `secretkey`
+## <a href="#secretkey" name="secretkey"></a> `secretkey`: `Handle`
 A secret key, for key exchange mechanisms.
 
 Size: 4
@@ -365,7 +362,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`
+## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`: `Handle`
 A state to absorb signed data to be verified.
 
 Size: 4
@@ -373,7 +370,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`
+## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`: `Handle`
 A state to perform symmetric operations.
 
 The state is not reset nor invalidated after an option has been performed.
@@ -384,7 +381,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`
+## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`: `Handle`
 A symmetric key.
 
 The key can be imported from raw bytes, or can be a reference to a managed key.
@@ -396,7 +393,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`
+## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`: `Handle`
 An authentication tag.
 
 This is an object returned by functions computing authentication tags.
@@ -412,19 +409,19 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: Enum(`u8`)
+## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: `Variant`
 Options index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_options_u.some" name="opt_options_u.some"></a> `some`
 
 - <a href="#opt_options_u.none" name="opt_options_u.none"></a> `none`
 
-## <a href="#opt_options" name="opt_options"></a> `opt_options`: Union
+## <a href="#opt_options" name="opt_options"></a> `opt_options`: `Variant`
 An optional options set.
 
 This union simulates an `Option<Options>` type to make the [`options`](#options) parameter of some functions optional.
@@ -433,30 +430,28 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_options.some" name="opt_options.some"></a> `some`: [`options`](#options)
 
 - <a href="#opt_options.none" name="opt_options.none"></a> `none`
 
-## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: Enum(`u8`)
+## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: `Variant`
 Symmetric key index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_symmetric_key_u.some" name="opt_symmetric_key_u.some"></a> `some`
 
 - <a href="#opt_symmetric_key_u.none" name="opt_symmetric_key_u.none"></a> `none`
 
-## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: Union
+## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: `Variant`
 An optional symmetric key.
 
 This union simulates an `Option<SymmetricKey>` type to make the [`symmetric_key`](#symmetric_key) parameter of some functions optional.
@@ -465,16 +460,20 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_symmetric_key.some" name="opt_symmetric_key.some"></a> `some`: [`symmetric_key`](#symmetric_key)
 
 - <a href="#opt_symmetric_key.none" name="opt_symmetric_key.none"></a> `none`
+
+## <a href="#u64" name="u64"></a> `u64`: `u64`
+
+Size: 8
+
+Alignment: 8
 
 # Modules
 ## <a href="#wasi_ephemeral_crypto_common" name="wasi_ephemeral_crypto_common"></a> wasi_ephemeral_crypto_common
@@ -484,7 +483,7 @@ Alignment: 4
 
 ---
 
-#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> (crypto_errno, options)`
+#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> Result<options, crypto_errno>`
 Create a new object to set non-default options.
 
 Example usage:
@@ -501,14 +500,21 @@ options_close(options_handle)?;
 - <a href="#options_open.algorithm_type" name="options_open.algorithm_type"></a> `algorithm_type`: [`algorithm_type`](#algorithm_type)
 
 ##### Results
-- <a href="#options_open.error" name="options_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_open.error" name="options_open.error"></a> `error`: `Result<options, crypto_errno>`
 
-- <a href="#options_open.handle" name="options_open.handle"></a> `handle`: [`options`](#options)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_open.error.ok" name="options_open.error.ok"></a> `ok`: [`options`](#options)
+
+- <a href="#options_open.error.err" name="options_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> crypto_errno`
+#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> Result<(), crypto_errno>`
 Destroy an options object.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -517,12 +523,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#options_close.handle" name="options_close.handle"></a> `handle`: [`options`](#options)
 
 ##### Results
-- <a href="#options_close.error" name="options_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_close.error" name="options_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_close.error.ok" name="options_close.error.ok"></a> `ok`
+
+- <a href="#options_close.error.err" name="options_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> crypto_errno`
+#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> Result<(), crypto_errno>`
 Set or update an option.
 
 This is used to set algorithm-specific parameters, but also to provide credentials for the secrets management facilities, if required.
@@ -539,12 +554,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set.value_len" name="options_set.value_len"></a> `value_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set.error" name="options_set.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set.error" name="options_set.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set.error.ok" name="options_set.error.ok"></a> `ok`
+
+- <a href="#options_set.error.err" name="options_set.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> crypto_errno`
+#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> Result<(), crypto_errno>`
 Set or update an integer option.
 
 This is used to set algorithm-specific parameters.
@@ -559,12 +583,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_u64.value" name="options_set_u64.value"></a> `value`: `u64`
 
 ##### Results
-- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_u64.error.ok" name="options_set_u64.error.ok"></a> `ok`
+
+- <a href="#options_set_u64.error.err" name="options_set_u64.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> crypto_errno`
+#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> Result<(), crypto_errno>`
 Set or update a guest-allocated memory that the host can use or return data into.
 
 This is for example used to set the scratch buffer required by memory-hard functions.
@@ -581,12 +614,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_guest_buffer.buffer_len" name="options_set_guest_buffer.buffer_len"></a> `buffer_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_guest_buffer.error.ok" name="options_set_guest_buffer.error.ok"></a> `ok`
+
+- <a href="#options_set_guest_buffer.error.err" name="options_set_guest_buffer.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> (crypto_errno, size)`
+#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> Result<size, crypto_errno>`
 Return the length of an [`array_output`](#array_output) object.
 
 This allows a guest to allocate a buffer of the correct size in order to copy the output of a function returning this object type.
@@ -595,14 +637,21 @@ This allows a guest to allocate a buffer of the correct size in order to copy th
 - <a href="#array_output_len.array_output" name="array_output_len.array_output"></a> `array_output`: [`array_output`](#array_output)
 
 ##### Results
-- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_len.len" name="array_output_len.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_len.error.ok" name="array_output_len.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_len.error.err" name="array_output_len.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> (crypto_errno, size)`
+#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> Result<size, crypto_errno>`
 Copy the content of an [`array_output`](#array_output) object into an application-allocated buffer.
 
 Multiple calls to that function can be made in order to consume the data in a streaming fashion, if necessary.
@@ -627,14 +676,21 @@ array_output_pull(output_handle, &mut out)?;
 - <a href="#array_output_pull.buf_len" name="array_output_pull.buf_len"></a> `buf_len`: [`size`](#size)
 
 ##### Results
-- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_pull.len" name="array_output_pull.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_pull.error.ok" name="array_output_pull.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_pull.error.err" name="array_output_pull.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> (crypto_errno, secrets_manager)`
+#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> Result<secrets_manager, crypto_errno>`
 __(optional)__
 Create a context to use a secrets manager.
 
@@ -647,14 +703,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_open.options" name="secrets_manager_open.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: `Result<secrets_manager, crypto_errno>`
 
-- <a href="#secrets_manager_open.handle" name="secrets_manager_open.handle"></a> `handle`: [`secrets_manager`](#secrets_manager)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_open.error.ok" name="secrets_manager_open.error.ok"></a> `ok`: [`secrets_manager`](#secrets_manager)
+
+- <a href="#secrets_manager_open.error.err" name="secrets_manager_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> crypto_errno`
+#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> Result<(), crypto_errno>`
 __(optional)__
 Destroy a secrets manager context.
 
@@ -665,12 +728,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_close.secrets_manager" name="secrets_manager_close.secrets_manager"></a> `secrets_manager`: [`secrets_manager`](#secrets_manager)
 
 ##### Results
-- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_close.error.ok" name="secrets_manager_close.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_close.error.err" name="secrets_manager_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> crypto_errno`
+#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> Result<(), crypto_errno>`
 __(optional)__
 Invalidate a managed key or key pair given an identifier and a version.
 
@@ -692,7 +764,16 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_invalidate.key_version" name="secrets_manager_invalidate.key_version"></a> `key_version`: [`version`](#version)
 
 ##### Results
-- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_invalidate.error.ok" name="secrets_manager_invalidate.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_invalidate.error.err" name="secrets_manager_invalidate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 ## <a href="#wasi_ephemeral_crypto_asymmetric_common" name="wasi_ephemeral_crypto_asymmetric_common"></a> wasi_ephemeral_crypto_asymmetric_common
 ### Imports
@@ -701,7 +782,7 @@ This is an optional import, meaning that the function may not even exist.
 
 ---
 
-#### <a href="#keypair_generate" name="keypair_generate"></a> `keypair_generate(algorithm_type: algorithm_type, algorithm: string, options: opt_options) -> (crypto_errno, keypair)`
+#### <a href="#keypair_generate" name="keypair_generate"></a> `keypair_generate(algorithm_type: algorithm_type, algorithm: string, options: opt_options) -> Result<keypair, crypto_errno>`
 Generate a new key pair.
 
 Internally, a key pair stores the supplied algorithm and optional parameters.
@@ -729,14 +810,21 @@ let kp_handle = ctx.keypair_generate(AlgorithmType::Signatures, "RSA_PKCS1_2048_
 - <a href="#keypair_generate.options" name="keypair_generate.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#keypair_generate.error" name="keypair_generate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_generate.error" name="keypair_generate.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_generate.handle" name="keypair_generate.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_generate.error.ok" name="keypair_generate.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_generate.error.err" name="keypair_generate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_import" name="keypair_import"></a> `keypair_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: keypair_encoding) -> (crypto_errno, keypair)`
+#### <a href="#keypair_import" name="keypair_import"></a> `keypair_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: keypair_encoding) -> Result<keypair, crypto_errno>`
 Import a key pair.
 
 This function creates a [`keypair`](#keypair) object from existing material.
@@ -763,14 +851,21 @@ let kp_handle = ctx.keypair_import(AlgorithmType::Signatures, "RSA_PKCS1_2048_SH
 - <a href="#keypair_import.encoding" name="keypair_import.encoding"></a> `encoding`: [`keypair_encoding`](#keypair_encoding)
 
 ##### Results
-- <a href="#keypair_import.error" name="keypair_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_import.error" name="keypair_import.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_import.handle" name="keypair_import.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_import.error.ok" name="keypair_import.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_import.error.err" name="keypair_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_generate_managed" name="keypair_generate_managed"></a> `keypair_generate_managed(secrets_manager: secrets_manager, algorithm_type: algorithm_type, algorithm: string, options: opt_options) -> (crypto_errno, keypair)`
+#### <a href="#keypair_generate_managed" name="keypair_generate_managed"></a> `keypair_generate_managed(secrets_manager: secrets_manager, algorithm_type: algorithm_type, algorithm: string, options: opt_options) -> Result<keypair, crypto_errno>`
 __(optional)__
 Generate a new managed key pair.
 
@@ -795,14 +890,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#keypair_generate_managed.options" name="keypair_generate_managed.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#keypair_generate_managed.error" name="keypair_generate_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_generate_managed.error" name="keypair_generate_managed.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_generate_managed.handle" name="keypair_generate_managed.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_generate_managed.error.ok" name="keypair_generate_managed.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_generate_managed.error.err" name="keypair_generate_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_store_managed" name="keypair_store_managed"></a> `keypair_store_managed(secrets_manager: secrets_manager, kp: keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> crypto_errno`
+#### <a href="#keypair_store_managed" name="keypair_store_managed"></a> `keypair_store_managed(secrets_manager: secrets_manager, kp: keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> Result<(), crypto_errno>`
 __(optional)__
 Store a key pair into the secrets manager.
 
@@ -821,12 +923,21 @@ The function returns `overflow` if the supplied buffer is too small.
 - <a href="#keypair_store_managed.kp_id_max_len" name="keypair_store_managed.kp_id_max_len"></a> `kp_id_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#keypair_store_managed.error" name="keypair_store_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_store_managed.error" name="keypair_store_managed.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_store_managed.error.ok" name="keypair_store_managed.error.ok"></a> `ok`
+
+- <a href="#keypair_store_managed.error.err" name="keypair_store_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_replace_managed" name="keypair_replace_managed"></a> `keypair_replace_managed(secrets_manager: secrets_manager, kp_old: keypair, kp_new: keypair) -> (crypto_errno, version)`
+#### <a href="#keypair_replace_managed" name="keypair_replace_managed"></a> `keypair_replace_managed(secrets_manager: secrets_manager, kp_old: keypair, kp_new: keypair) -> Result<version, crypto_errno>`
 __(optional)__
 Replace a managed key pair.
 
@@ -857,14 +968,21 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#keypair_replace_managed.kp_new" name="keypair_replace_managed.kp_new"></a> `kp_new`: [`keypair`](#keypair)
 
 ##### Results
-- <a href="#keypair_replace_managed.error" name="keypair_replace_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_replace_managed.error" name="keypair_replace_managed.error"></a> `error`: `Result<version, crypto_errno>`
 
-- <a href="#keypair_replace_managed.version" name="keypair_replace_managed.version"></a> `version`: [`version`](#version)
+###### Variant Layout
+- size: 16
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_replace_managed.error.ok" name="keypair_replace_managed.error.ok"></a> `ok`: [`version`](#version)
+
+- <a href="#keypair_replace_managed.error.err" name="keypair_replace_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_id" name="keypair_id"></a> `keypair_id(kp: keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> (crypto_errno, size, version)`
+#### <a href="#keypair_id" name="keypair_id"></a> `keypair_id(kp: keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> Result<(size, version), crypto_errno>`
 __(optional)__
 Return the key pair identifier and version of a managed key pair.
 
@@ -880,16 +998,30 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#keypair_id.kp_id_max_len" name="keypair_id.kp_id_max_len"></a> `kp_id_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#keypair_id.error" name="keypair_id.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_id.error" name="keypair_id.error"></a> `error`: `Result<(size, version), crypto_errno>`
 
-- <a href="#keypair_id.kp_id_len" name="keypair_id.kp_id_len"></a> `kp_id_len`: [`size`](#size)
+###### Variant Layout
+- size: 24
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_id.error.ok" name="keypair_id.error.ok"></a> `ok`: `(size, version)`
 
-- <a href="#keypair_id.version" name="keypair_id.version"></a> `version`: [`version`](#version)
+####### Record members
+- <a href="#keypair_id.error.ok.0" name="keypair_id.error.ok.0"></a> `0`: [`size`](#size)
+
+Offset: 0
+
+- <a href="#keypair_id.error.ok.1" name="keypair_id.error.ok.1"></a> `1`: [`version`](#version)
+
+Offset: 8
+
+- <a href="#keypair_id.error.err" name="keypair_id.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_from_id" name="keypair_from_id"></a> `keypair_from_id(secrets_manager: secrets_manager, kp_id: ConstPointer<u8>, kp_id_len: size, kp_version: version) -> (crypto_errno, keypair)`
+#### <a href="#keypair_from_id" name="keypair_from_id"></a> `keypair_from_id(secrets_manager: secrets_manager, kp_id: ConstPointer<u8>, kp_id_len: size, kp_version: version) -> Result<keypair, crypto_errno>`
 __(optional)__
 Return a managed key pair from a key identifier.
 
@@ -909,14 +1041,21 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#keypair_from_id.kp_version" name="keypair_from_id.kp_version"></a> `kp_version`: [`version`](#version)
 
 ##### Results
-- <a href="#keypair_from_id.error" name="keypair_from_id.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_from_id.error" name="keypair_from_id.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_from_id.handle" name="keypair_from_id.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_from_id.error.ok" name="keypair_from_id.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_from_id.error.err" name="keypair_from_id.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_from_pk_and_sk" name="keypair_from_pk_and_sk"></a> `keypair_from_pk_and_sk(publickey: publickey, secretkey: secretkey) -> (crypto_errno, keypair)`
+#### <a href="#keypair_from_pk_and_sk" name="keypair_from_pk_and_sk"></a> `keypair_from_pk_and_sk(publickey: publickey, secretkey: secretkey) -> Result<keypair, crypto_errno>`
 Create a key pair from a public key and a secret key.
 
 ##### Params
@@ -925,14 +1064,21 @@ Create a key pair from a public key and a secret key.
 - <a href="#keypair_from_pk_and_sk.secretkey" name="keypair_from_pk_and_sk.secretkey"></a> `secretkey`: [`secretkey`](#secretkey)
 
 ##### Results
-- <a href="#keypair_from_pk_and_sk.error" name="keypair_from_pk_and_sk.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_from_pk_and_sk.error" name="keypair_from_pk_and_sk.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_from_pk_and_sk.handle" name="keypair_from_pk_and_sk.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_from_pk_and_sk.error.ok" name="keypair_from_pk_and_sk.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_from_pk_and_sk.error.err" name="keypair_from_pk_and_sk.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_export" name="keypair_export"></a> `keypair_export(kp: keypair, encoding: keypair_encoding) -> (crypto_errno, array_output)`
+#### <a href="#keypair_export" name="keypair_export"></a> `keypair_export(kp: keypair, encoding: keypair_encoding) -> Result<array_output, crypto_errno>`
 Export a key pair as the given encoding format.
 
 May return `prohibited_operation` if this operation is denied or `unsupported_encoding` if the encoding is not supported.
@@ -943,42 +1089,63 @@ May return `prohibited_operation` if this operation is denied or `unsupported_en
 - <a href="#keypair_export.encoding" name="keypair_export.encoding"></a> `encoding`: [`keypair_encoding`](#keypair_encoding)
 
 ##### Results
-- <a href="#keypair_export.error" name="keypair_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_export.error" name="keypair_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#keypair_export.encoded" name="keypair_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_export.error.ok" name="keypair_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#keypair_export.error.err" name="keypair_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_publickey" name="keypair_publickey"></a> `keypair_publickey(kp: keypair) -> (crypto_errno, publickey)`
+#### <a href="#keypair_publickey" name="keypair_publickey"></a> `keypair_publickey(kp: keypair) -> Result<publickey, crypto_errno>`
 Get the public key of a key pair.
 
 ##### Params
 - <a href="#keypair_publickey.kp" name="keypair_publickey.kp"></a> `kp`: [`keypair`](#keypair)
 
 ##### Results
-- <a href="#keypair_publickey.error" name="keypair_publickey.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_publickey.error" name="keypair_publickey.error"></a> `error`: `Result<publickey, crypto_errno>`
 
-- <a href="#keypair_publickey.pk" name="keypair_publickey.pk"></a> `pk`: [`publickey`](#publickey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_publickey.error.ok" name="keypair_publickey.error.ok"></a> `ok`: [`publickey`](#publickey)
+
+- <a href="#keypair_publickey.error.err" name="keypair_publickey.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_secretkey" name="keypair_secretkey"></a> `keypair_secretkey(kp: keypair) -> (crypto_errno, secretkey)`
+#### <a href="#keypair_secretkey" name="keypair_secretkey"></a> `keypair_secretkey(kp: keypair) -> Result<secretkey, crypto_errno>`
 Get the secret key of a key pair.
 
 ##### Params
 - <a href="#keypair_secretkey.kp" name="keypair_secretkey.kp"></a> `kp`: [`keypair`](#keypair)
 
 ##### Results
-- <a href="#keypair_secretkey.error" name="keypair_secretkey.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_secretkey.error" name="keypair_secretkey.error"></a> `error`: `Result<secretkey, crypto_errno>`
 
-- <a href="#keypair_secretkey.sk" name="keypair_secretkey.sk"></a> `sk`: [`secretkey`](#secretkey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_secretkey.error.ok" name="keypair_secretkey.error.ok"></a> `ok`: [`secretkey`](#secretkey)
+
+- <a href="#keypair_secretkey.error.err" name="keypair_secretkey.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_close" name="keypair_close"></a> `keypair_close(kp: keypair) -> crypto_errno`
+#### <a href="#keypair_close" name="keypair_close"></a> `keypair_close(kp: keypair) -> Result<(), crypto_errno>`
 Destroy a key pair.
 
 The host will automatically wipe traces of the secret key from memory.
@@ -989,12 +1156,21 @@ If this is a managed key, the key will not be removed from persistent storage, a
 - <a href="#keypair_close.kp" name="keypair_close.kp"></a> `kp`: [`keypair`](#keypair)
 
 ##### Results
-- <a href="#keypair_close.error" name="keypair_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_close.error" name="keypair_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_close.error.ok" name="keypair_close.error.ok"></a> `ok`
+
+- <a href="#keypair_close.error.err" name="keypair_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_import" name="publickey_import"></a> `publickey_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: publickey_encoding) -> (crypto_errno, publickey)`
+#### <a href="#publickey_import" name="publickey_import"></a> `publickey_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: publickey_encoding) -> Result<publickey, crypto_errno>`
 Import a public key.
 
 The function may return `unsupported_encoding` if importing from the given format is not implemented or incompatible with the key type.
@@ -1021,14 +1197,21 @@ let pk_handle = ctx.publickey_import(AlgorithmType::Signatures, encoded, PublicK
 - <a href="#publickey_import.encoding" name="publickey_import.encoding"></a> `encoding`: [`publickey_encoding`](#publickey_encoding)
 
 ##### Results
-- <a href="#publickey_import.error" name="publickey_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_import.error" name="publickey_import.error"></a> `error`: `Result<publickey, crypto_errno>`
 
-- <a href="#publickey_import.pk" name="publickey_import.pk"></a> `pk`: [`publickey`](#publickey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_import.error.ok" name="publickey_import.error.ok"></a> `ok`: [`publickey`](#publickey)
+
+- <a href="#publickey_import.error.err" name="publickey_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_export" name="publickey_export"></a> `publickey_export(pk: publickey, encoding: publickey_encoding) -> (crypto_errno, array_output)`
+#### <a href="#publickey_export" name="publickey_export"></a> `publickey_export(pk: publickey, encoding: publickey_encoding) -> Result<array_output, crypto_errno>`
 Export a public key as the given encoding format.
 
 May return `unsupported_encoding` if the encoding is not supported.
@@ -1039,14 +1222,21 @@ May return `unsupported_encoding` if the encoding is not supported.
 - <a href="#publickey_export.encoding" name="publickey_export.encoding"></a> `encoding`: [`publickey_encoding`](#publickey_encoding)
 
 ##### Results
-- <a href="#publickey_export.error" name="publickey_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_export.error" name="publickey_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#publickey_export.encoded" name="publickey_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_export.error.ok" name="publickey_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#publickey_export.error.err" name="publickey_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_verify" name="publickey_verify"></a> `publickey_verify(pk: publickey) -> crypto_errno`
+#### <a href="#publickey_verify" name="publickey_verify"></a> `publickey_verify(pk: publickey) -> Result<(), crypto_errno>`
 Check that a public key is valid and in canonical form.
 
 This function may perform stricter checks than those made during importation at the expense of additional CPU cycles.
@@ -1057,26 +1247,42 @@ The function returns `invalid_key` if the public key didn't pass the checks.
 - <a href="#publickey_verify.pk" name="publickey_verify.pk"></a> `pk`: [`publickey`](#publickey)
 
 ##### Results
-- <a href="#publickey_verify.error" name="publickey_verify.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_verify.error" name="publickey_verify.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_verify.error.ok" name="publickey_verify.error.ok"></a> `ok`
+
+- <a href="#publickey_verify.error.err" name="publickey_verify.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_from_secretkey" name="publickey_from_secretkey"></a> `publickey_from_secretkey(sk: secretkey) -> (crypto_errno, publickey)`
+#### <a href="#publickey_from_secretkey" name="publickey_from_secretkey"></a> `publickey_from_secretkey(sk: secretkey) -> Result<publickey, crypto_errno>`
 Compute the public key for a secret key.
 
 ##### Params
 - <a href="#publickey_from_secretkey.sk" name="publickey_from_secretkey.sk"></a> `sk`: [`secretkey`](#secretkey)
 
 ##### Results
-- <a href="#publickey_from_secretkey.error" name="publickey_from_secretkey.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_from_secretkey.error" name="publickey_from_secretkey.error"></a> `error`: `Result<publickey, crypto_errno>`
 
-- <a href="#publickey_from_secretkey.pk" name="publickey_from_secretkey.pk"></a> `pk`: [`publickey`](#publickey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_from_secretkey.error.ok" name="publickey_from_secretkey.error.ok"></a> `ok`: [`publickey`](#publickey)
+
+- <a href="#publickey_from_secretkey.error.err" name="publickey_from_secretkey.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_close" name="publickey_close"></a> `publickey_close(pk: publickey) -> crypto_errno`
+#### <a href="#publickey_close" name="publickey_close"></a> `publickey_close(pk: publickey) -> Result<(), crypto_errno>`
 Destroy a public key.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1085,12 +1291,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#publickey_close.pk" name="publickey_close.pk"></a> `pk`: [`publickey`](#publickey)
 
 ##### Results
-- <a href="#publickey_close.error" name="publickey_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_close.error" name="publickey_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_close.error.ok" name="publickey_close.error.ok"></a> `ok`
+
+- <a href="#publickey_close.error.err" name="publickey_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secretkey_import" name="secretkey_import"></a> `secretkey_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: secretkey_encoding) -> (crypto_errno, secretkey)`
+#### <a href="#secretkey_import" name="secretkey_import"></a> `secretkey_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: secretkey_encoding) -> Result<secretkey, crypto_errno>`
 Import a secret key.
 
 The function may return `unsupported_encoding` if importing from the given format is not implemented or incompatible with the key type.
@@ -1117,14 +1332,21 @@ let pk_handle = ctx.secretkey_import(AlgorithmType::KX, encoded, SecretKeyEncodi
 - <a href="#secretkey_import.encoding" name="secretkey_import.encoding"></a> `encoding`: [`secretkey_encoding`](#secretkey_encoding)
 
 ##### Results
-- <a href="#secretkey_import.error" name="secretkey_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secretkey_import.error" name="secretkey_import.error"></a> `error`: `Result<secretkey, crypto_errno>`
 
-- <a href="#secretkey_import.sk" name="secretkey_import.sk"></a> `sk`: [`secretkey`](#secretkey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secretkey_import.error.ok" name="secretkey_import.error.ok"></a> `ok`: [`secretkey`](#secretkey)
+
+- <a href="#secretkey_import.error.err" name="secretkey_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secretkey_export" name="secretkey_export"></a> `secretkey_export(sk: secretkey, encoding: secretkey_encoding) -> (crypto_errno, array_output)`
+#### <a href="#secretkey_export" name="secretkey_export"></a> `secretkey_export(sk: secretkey, encoding: secretkey_encoding) -> Result<array_output, crypto_errno>`
 Export a secret key as the given encoding format.
 
 May return `unsupported_encoding` if the encoding is not supported.
@@ -1135,14 +1357,21 @@ May return `unsupported_encoding` if the encoding is not supported.
 - <a href="#secretkey_export.encoding" name="secretkey_export.encoding"></a> `encoding`: [`secretkey_encoding`](#secretkey_encoding)
 
 ##### Results
-- <a href="#secretkey_export.error" name="secretkey_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secretkey_export.error" name="secretkey_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#secretkey_export.encoded" name="secretkey_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secretkey_export.error.ok" name="secretkey_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#secretkey_export.error.err" name="secretkey_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secretkey_close" name="secretkey_close"></a> `secretkey_close(sk: secretkey) -> crypto_errno`
+#### <a href="#secretkey_close" name="secretkey_close"></a> `secretkey_close(sk: secretkey) -> Result<(), crypto_errno>`
 Destroy a secret key.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1151,5 +1380,15 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#secretkey_close.sk" name="secretkey_close.sk"></a> `sk`: [`secretkey`](#secretkey)
 
 ##### Results
-- <a href="#secretkey_close.error" name="secretkey_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secretkey_close.error" name="secretkey_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secretkey_close.error.ok" name="secretkey_close.error.ok"></a> `ok`
+
+- <a href="#secretkey_close.error.err" name="secretkey_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
+
 

--- a/witx/proposal_asymmetric_common.witx
+++ b/witx/proposal_asymmetric_common.witx
@@ -25,8 +25,7 @@
     (param $algorithm_type $algorithm_type)
     (param $algorithm string)
     (param $options $opt_options)
-    (result $error $crypto_errno)
-    (result $handle $keypair)
+    (result $error (expected $keypair (error $crypto_errno)))
   )
 
   ;;; Import a key pair.
@@ -48,8 +47,7 @@
     (param $encoded (@witx const_pointer u8))
     (param $encoded_len $size)
     (param $encoding $keypair_encoding)
-    (result $error $crypto_errno)
-    (result $handle $keypair)
+    (result $error (expected $keypair (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -70,8 +68,7 @@
     (param $algorithm_type $algorithm_type)
     (param $algorithm string)
     (param $options $opt_options)
-    (result $error $crypto_errno)
-    (result $handle $keypair)
+    (result $error (expected $keypair (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -86,7 +83,7 @@
     (param $kp $keypair)
     (param $kp_id (@witx pointer u8))
     (param $kp_id_max_len $size)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -114,8 +111,7 @@
     (param $secrets_manager $secrets_manager)
     (param $kp_old $keypair)
     (param $kp_new $keypair)
-    (result $error $crypto_errno)
-    (result $version $version)
+    (result $error (expected $version (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -128,9 +124,7 @@
     (param $kp $keypair)
     (param $kp_id (@witx pointer u8))
     (param $kp_id_max_len $size)
-    (result $error $crypto_errno)
-    (result $kp_id_len $size)
-    (result $version $version)
+    (result $error (expected (tuple $size $version) (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -147,16 +141,14 @@
     (param $kp_id (@witx const_pointer u8))
     (param $kp_id_len $size)
     (param $kp_version $version)
-    (result $error $crypto_errno)
-    (result $handle $keypair)
+    (result $error (expected $keypair (error $crypto_errno)))
   )
 
   ;;; Create a key pair from a public key and a secret key.
   (@interface func (export "keypair_from_pk_and_sk")
     (param $publickey $publickey)
     (param $secretkey $secretkey)
-    (result $error $crypto_errno)
-    (result $handle $keypair)
+    (result $error (expected $keypair (error $crypto_errno)))
   )
 
   ;;; Export a key pair as the given encoding format.
@@ -165,22 +157,19 @@
   (@interface func (export "keypair_export")
     (param $kp $keypair)
     (param $encoding $keypair_encoding)
-    (result $error $crypto_errno)
-    (result $encoded $array_output)
+    (result $error (expected $array_output (error $crypto_errno)))
   )
 
   ;;; Get the public key of a key pair.
   (@interface func (export "keypair_publickey")
     (param $kp $keypair)
-    (result $error $crypto_errno)
-    (result $pk $publickey)
+    (result $error (expected $publickey (error $crypto_errno)))
   )
 
   ;;; Get the secret key of a key pair.
   (@interface func (export "keypair_secretkey")
     (param $kp $keypair)
-    (result $error $crypto_errno)
-    (result $sk $secretkey)
+    (result $error (expected $secretkey (error $crypto_errno)))
   )
 
   ;;; Destroy a key pair.
@@ -190,7 +179,7 @@
   ;;; If this is a managed key, the key will not be removed from persistent storage, and can be reconstructed later using the key identifier.
   (@interface func (export "keypair_close")
     (param $kp $keypair)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Import a public key.
@@ -212,8 +201,7 @@
     (param $encoded (@witx const_pointer u8))
     (param $encoded_len $size)
     (param $encoding $publickey_encoding)
-    (result $error $crypto_errno)
-    (result $pk $publickey)
+    (result $error (expected $publickey (error $crypto_errno)))
   )
 
   ;;; Export a public key as the given encoding format.
@@ -222,8 +210,7 @@
   (@interface func (export "publickey_export")
     (param $pk $publickey)
     (param $encoding $publickey_encoding)
-    (result $error $crypto_errno)
-    (result $encoded $array_output)
+    (result $error (expected $array_output (error $crypto_errno)))
   )
 
   ;;; Check that a public key is valid and in canonical form.
@@ -233,14 +220,13 @@
   ;;; The function returns `invalid_key` if the public key didn't pass the checks.
   (@interface func (export "publickey_verify")
     (param $pk $publickey)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Compute the public key for a secret key.
   (@interface func (export "publickey_from_secretkey")
     (param $sk $secretkey)
-    (result $error $crypto_errno)
-    (result $pk $publickey)
+    (result $error (expected $publickey (error $crypto_errno)))
   )
 
   ;;; Destroy a public key.
@@ -248,7 +234,7 @@
   ;;; Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
   (@interface func (export "publickey_close")
     (param $pk $publickey)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Import a secret key.
@@ -270,8 +256,7 @@
     (param $encoded (@witx const_pointer u8))
     (param $encoded_len $size)
     (param $encoding $secretkey_encoding)
-    (result $error $crypto_errno)
-    (result $sk $secretkey)
+    (result $error (expected $secretkey (error $crypto_errno)))
   )
 
   ;;; Export a secret key as the given encoding format.
@@ -280,8 +265,7 @@
   (@interface func (export "secretkey_export")
     (param $sk $secretkey)
     (param $encoding $secretkey_encoding)
-    (result $error $crypto_errno)
-    (result $encoded $array_output)
+    (result $error (expected $array_output (error $crypto_errno)))
   )
 
   ;;; Destroy a secret key.
@@ -289,6 +273,6 @@
   ;;; Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
   (@interface func (export "secretkey_close")
     (param $sk $secretkey)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 )

--- a/witx/proposal_common.md
+++ b/witx/proposal_common.md
@@ -1,12 +1,12 @@
 # Types
-## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: Enum(`u16`)
+## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: `Variant`
 Error codes.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#crypto_errno.success" name="crypto_errno.success"></a> `success`
 Operation succeeded.
 
@@ -151,14 +151,14 @@ This error is returned when trying to build a key pair from a public key and a s
 - <a href="#crypto_errno.expired" name="crypto_errno.expired"></a> `expired`
 A managed key or secret expired and cannot be used any more.
 
-## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: Enum(`u16`)
+## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: `Variant`
 Encoding to use for importing or exporting a key pair.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#keypair_encoding.raw" name="keypair_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -171,14 +171,14 @@ PEM encoding.
 - <a href="#keypair_encoding.local" name="keypair_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: Enum(`u16`)
+## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: `Variant`
 Encoding to use for importing or exporting a public key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#publickey_encoding.raw" name="publickey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -197,14 +197,14 @@ Compressed SEC encoding.
 - <a href="#publickey_encoding.local" name="publickey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: Enum(`u16`)
+## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: `Variant`
 Encoding to use for importing or exporting a secret key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#secretkey_encoding.raw" name="secretkey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -223,52 +223,49 @@ Compressed SEC encoding.
 - <a href="#secretkey_encoding.local" name="secretkey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: Enum(`u16`)
+## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: `Variant`
 Encoding to use for importing or exporting a signature.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#signature_encoding.raw" name="signature_encoding.raw"></a> `raw`
 Raw bytes.
 
 - <a href="#signature_encoding.der" name="signature_encoding.der"></a> `der`
 DER encoding.
 
-## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: Enum(`u16`)
+## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: `Variant`
 An algorithm category.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#algorithm_type.signatures" name="algorithm_type.signatures"></a> `signatures`
 
 - <a href="#algorithm_type.symmetric" name="algorithm_type.symmetric"></a> `symmetric`
 
 - <a href="#algorithm_type.key_exchange" name="algorithm_type.key_exchange"></a> `key_exchange`
 
-## <a href="#version" name="version"></a> `version`: Int(`u64`)
+## <a href="#version" name="version"></a> `version`: `u64`
 Version of a managed key.
 
-A version can be an arbitrary `u64` integer, with the expection of some reserved values.
+A version can be an arbitrary [`u64`](#u64) integer, with the expection of some reserved values.
 
 Size: 8
 
 Alignment: 8
 
-### Consts
+### Constants
 - <a href="#version.unspecified" name="version.unspecified"></a> `unspecified`
-Key doesn't support versioning.
 
 - <a href="#version.latest" name="version.latest"></a> `latest`
-Use the latest version of a key.
 
 - <a href="#version.all" name="version.all"></a> `all`
-Perform an operation over all versions of a key.
 
 ## <a href="#size" name="size"></a> `size`: `usize`
 Size of a value.
@@ -284,7 +281,7 @@ Size: 8
 
 Alignment: 8
 
-## <a href="#array_output" name="array_output"></a> `array_output`
+## <a href="#array_output" name="array_output"></a> `array_output`: `Handle`
 Handle for functions returning output whose size may be large or not known in advance.
 
 An [`array_output`](#array_output) object contains a host-allocated byte array.
@@ -299,7 +296,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#options" name="options"></a> `options`
+## <a href="#options" name="options"></a> `options`: `Handle`
 A set of options.
 
 This type is used to set non-default parameters.
@@ -311,7 +308,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`
+## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`: `Handle`
 A handle to the optional secrets management facilities offered by a host.
 
 This is used to generate, retrieve and invalidate managed keys.
@@ -321,7 +318,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#keypair" name="keypair"></a> `keypair`
+## <a href="#keypair" name="keypair"></a> `keypair`: `Handle`
 A key pair.
 
 Size: 4
@@ -329,7 +326,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_state" name="signature_state"></a> `signature_state`
+## <a href="#signature_state" name="signature_state"></a> `signature_state`: `Handle`
 A state to absorb data to be signed.
 
 After a signature has been computed or verified, the state remains valid for further operations.
@@ -341,7 +338,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature" name="signature"></a> `signature`
+## <a href="#signature" name="signature"></a> `signature`: `Handle`
 A signature.
 
 Size: 4
@@ -349,7 +346,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#publickey" name="publickey"></a> `publickey`
+## <a href="#publickey" name="publickey"></a> `publickey`: `Handle`
 A public key, for key exchange and signature verification.
 
 Size: 4
@@ -357,7 +354,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secretkey" name="secretkey"></a> `secretkey`
+## <a href="#secretkey" name="secretkey"></a> `secretkey`: `Handle`
 A secret key, for key exchange mechanisms.
 
 Size: 4
@@ -365,7 +362,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`
+## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`: `Handle`
 A state to absorb signed data to be verified.
 
 Size: 4
@@ -373,7 +370,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`
+## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`: `Handle`
 A state to perform symmetric operations.
 
 The state is not reset nor invalidated after an option has been performed.
@@ -384,7 +381,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`
+## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`: `Handle`
 A symmetric key.
 
 The key can be imported from raw bytes, or can be a reference to a managed key.
@@ -396,7 +393,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`
+## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`: `Handle`
 An authentication tag.
 
 This is an object returned by functions computing authentication tags.
@@ -412,19 +409,19 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: Enum(`u8`)
+## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: `Variant`
 Options index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_options_u.some" name="opt_options_u.some"></a> `some`
 
 - <a href="#opt_options_u.none" name="opt_options_u.none"></a> `none`
 
-## <a href="#opt_options" name="opt_options"></a> `opt_options`: Union
+## <a href="#opt_options" name="opt_options"></a> `opt_options`: `Variant`
 An optional options set.
 
 This union simulates an `Option<Options>` type to make the [`options`](#options) parameter of some functions optional.
@@ -433,30 +430,28 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_options.some" name="opt_options.some"></a> `some`: [`options`](#options)
 
 - <a href="#opt_options.none" name="opt_options.none"></a> `none`
 
-## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: Enum(`u8`)
+## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: `Variant`
 Symmetric key index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_symmetric_key_u.some" name="opt_symmetric_key_u.some"></a> `some`
 
 - <a href="#opt_symmetric_key_u.none" name="opt_symmetric_key_u.none"></a> `none`
 
-## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: Union
+## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: `Variant`
 An optional symmetric key.
 
 This union simulates an `Option<SymmetricKey>` type to make the [`symmetric_key`](#symmetric_key) parameter of some functions optional.
@@ -465,16 +460,20 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_symmetric_key.some" name="opt_symmetric_key.some"></a> `some`: [`symmetric_key`](#symmetric_key)
 
 - <a href="#opt_symmetric_key.none" name="opt_symmetric_key.none"></a> `none`
+
+## <a href="#u64" name="u64"></a> `u64`: `u64`
+
+Size: 8
+
+Alignment: 8
 
 # Modules
 ## <a href="#wasi_ephemeral_crypto_common" name="wasi_ephemeral_crypto_common"></a> wasi_ephemeral_crypto_common
@@ -484,7 +483,7 @@ Alignment: 4
 
 ---
 
-#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> (crypto_errno, options)`
+#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> Result<options, crypto_errno>`
 Create a new object to set non-default options.
 
 Example usage:
@@ -501,14 +500,21 @@ options_close(options_handle)?;
 - <a href="#options_open.algorithm_type" name="options_open.algorithm_type"></a> `algorithm_type`: [`algorithm_type`](#algorithm_type)
 
 ##### Results
-- <a href="#options_open.error" name="options_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_open.error" name="options_open.error"></a> `error`: `Result<options, crypto_errno>`
 
-- <a href="#options_open.handle" name="options_open.handle"></a> `handle`: [`options`](#options)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_open.error.ok" name="options_open.error.ok"></a> `ok`: [`options`](#options)
+
+- <a href="#options_open.error.err" name="options_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> crypto_errno`
+#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> Result<(), crypto_errno>`
 Destroy an options object.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -517,12 +523,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#options_close.handle" name="options_close.handle"></a> `handle`: [`options`](#options)
 
 ##### Results
-- <a href="#options_close.error" name="options_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_close.error" name="options_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_close.error.ok" name="options_close.error.ok"></a> `ok`
+
+- <a href="#options_close.error.err" name="options_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> crypto_errno`
+#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> Result<(), crypto_errno>`
 Set or update an option.
 
 This is used to set algorithm-specific parameters, but also to provide credentials for the secrets management facilities, if required.
@@ -539,12 +554,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set.value_len" name="options_set.value_len"></a> `value_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set.error" name="options_set.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set.error" name="options_set.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set.error.ok" name="options_set.error.ok"></a> `ok`
+
+- <a href="#options_set.error.err" name="options_set.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> crypto_errno`
+#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> Result<(), crypto_errno>`
 Set or update an integer option.
 
 This is used to set algorithm-specific parameters.
@@ -559,12 +583,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_u64.value" name="options_set_u64.value"></a> `value`: `u64`
 
 ##### Results
-- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_u64.error.ok" name="options_set_u64.error.ok"></a> `ok`
+
+- <a href="#options_set_u64.error.err" name="options_set_u64.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> crypto_errno`
+#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> Result<(), crypto_errno>`
 Set or update a guest-allocated memory that the host can use or return data into.
 
 This is for example used to set the scratch buffer required by memory-hard functions.
@@ -581,12 +614,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_guest_buffer.buffer_len" name="options_set_guest_buffer.buffer_len"></a> `buffer_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_guest_buffer.error.ok" name="options_set_guest_buffer.error.ok"></a> `ok`
+
+- <a href="#options_set_guest_buffer.error.err" name="options_set_guest_buffer.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> (crypto_errno, size)`
+#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> Result<size, crypto_errno>`
 Return the length of an [`array_output`](#array_output) object.
 
 This allows a guest to allocate a buffer of the correct size in order to copy the output of a function returning this object type.
@@ -595,14 +637,21 @@ This allows a guest to allocate a buffer of the correct size in order to copy th
 - <a href="#array_output_len.array_output" name="array_output_len.array_output"></a> `array_output`: [`array_output`](#array_output)
 
 ##### Results
-- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_len.len" name="array_output_len.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_len.error.ok" name="array_output_len.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_len.error.err" name="array_output_len.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> (crypto_errno, size)`
+#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> Result<size, crypto_errno>`
 Copy the content of an [`array_output`](#array_output) object into an application-allocated buffer.
 
 Multiple calls to that function can be made in order to consume the data in a streaming fashion, if necessary.
@@ -627,14 +676,21 @@ array_output_pull(output_handle, &mut out)?;
 - <a href="#array_output_pull.buf_len" name="array_output_pull.buf_len"></a> `buf_len`: [`size`](#size)
 
 ##### Results
-- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_pull.len" name="array_output_pull.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_pull.error.ok" name="array_output_pull.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_pull.error.err" name="array_output_pull.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> (crypto_errno, secrets_manager)`
+#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> Result<secrets_manager, crypto_errno>`
 __(optional)__
 Create a context to use a secrets manager.
 
@@ -647,14 +703,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_open.options" name="secrets_manager_open.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: `Result<secrets_manager, crypto_errno>`
 
-- <a href="#secrets_manager_open.handle" name="secrets_manager_open.handle"></a> `handle`: [`secrets_manager`](#secrets_manager)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_open.error.ok" name="secrets_manager_open.error.ok"></a> `ok`: [`secrets_manager`](#secrets_manager)
+
+- <a href="#secrets_manager_open.error.err" name="secrets_manager_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> crypto_errno`
+#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> Result<(), crypto_errno>`
 __(optional)__
 Destroy a secrets manager context.
 
@@ -665,12 +728,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_close.secrets_manager" name="secrets_manager_close.secrets_manager"></a> `secrets_manager`: [`secrets_manager`](#secrets_manager)
 
 ##### Results
-- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_close.error.ok" name="secrets_manager_close.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_close.error.err" name="secrets_manager_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> crypto_errno`
+#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> Result<(), crypto_errno>`
 __(optional)__
 Invalidate a managed key or key pair given an identifier and a version.
 
@@ -692,5 +764,15 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_invalidate.key_version" name="secrets_manager_invalidate.key_version"></a> `key_version`: [`version`](#version)
 
 ##### Results
-- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_invalidate.error.ok" name="secrets_manager_invalidate.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_invalidate.error.err" name="secrets_manager_invalidate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
+
 

--- a/witx/proposal_common.witx
+++ b/witx/proposal_common.witx
@@ -1,6 +1,6 @@
 ;;; Error codes.
 (typename $crypto_errno
-  (enum u16
+  (enum (@witx tag u16)
     ;;; Operation succeeded.
     $success
 
@@ -149,7 +149,7 @@
 
 ;;; Encoding to use for importing or exporting a key pair.
 (typename $keypair_encoding
-  (enum u16
+  (enum (@witx tag u16)
     ;;; Raw bytes.
     $raw
 
@@ -166,7 +166,7 @@
 
 ;;; Encoding to use for importing or exporting a public key.
 (typename $publickey_encoding
-  (enum u16
+  (enum (@witx tag u16)
     ;;; Raw bytes.
     $raw
 
@@ -189,7 +189,7 @@
 
 ;;; Encoding to use for importing or exporting a secret key.
 (typename $secretkey_encoding
-  (enum u16
+  (enum (@witx tag u16)
     ;;; Raw bytes.
     $raw
 
@@ -212,7 +212,7 @@
 
 ;;; Encoding to use for importing or exporting a signature.
 (typename $signature_encoding
-  (enum u16
+  (enum (@witx tag u16)
     ;;; Raw bytes.
     $raw
 
@@ -223,7 +223,7 @@
 
 ;;; An algorithm category.
 (typename $algorithm_type
-  (enum u16
+  (enum (@witx tag u16)
     $signatures
     $symmetric
     $key_exchange
@@ -233,19 +233,15 @@
 ;;; Version of a managed key.
 ;;;
 ;;; A version can be an arbitrary `u64` integer, with the expection of some reserved values.
-(typename $version
-  (int u64
-    ;;; Key doesn't support versioning.
+(typename $version u64)
+;;; Key doesn't support versioning.
+(@witx const $version $unspecified 0xff00000000000000)
 
-    (const $unspecified 0xff00000000000000)
-    ;;; Use the latest version of a key.
+;;; Use the latest version of a key.
+(@witx const $version $latest 0xff00000000000001)
 
-    (const $latest 0xff00000000000001)
-
-    ;;; Perform an operation over all versions of a key.
-    (const $all 0xff00000000000002)
-  )
-)
+;;; Perform an operation over all versions of a key.
+(@witx const $version $all 0xff00000000000002)
 
 ;;; Size of a value.
 (typename $size (@witx usize))
@@ -322,20 +318,20 @@
 (typename $symmetric_tag (handle))
 
 ;;; Options index, only required by the Interface Types translation layer.
-(typename $opt_options_u (enum u8 $some $none))
+(typename $opt_options_u (enum (@witx tag u8) $some $none))
 
 ;;; An optional options set.
 ;;;
 ;;; This union simulates an `Option<Options>` type to make the `options` parameter of some functions optional.
-(typename $opt_options (union $opt_options_u (field $some $options) (empty $none)))
+(typename $opt_options (variant (@witx tag $opt_options_u) (case $some $options) (case $none)))
 
 ;;; Symmetric key index, only required by the Interface Types translation layer.
-(typename $opt_symmetric_key_u (enum u8 $some $none))
+(typename $opt_symmetric_key_u (enum (@witx tag u8) $some $none))
 
 ;;; An optional symmetric key.
 ;;;
 ;;; This union simulates an `Option<SymmetricKey>` type to make the `symmetric_key` parameter of some functions optional.
-(typename $opt_symmetric_key (union $opt_symmetric_key_u (field $some $symmetric_key) (empty $none)))
+(typename $opt_symmetric_key (variant (@witx tag $opt_symmetric_key_u) (case $some $symmetric_key) (case $none)))
 
 (module $wasi_ephemeral_crypto_common
   (import "memory" (memory))
@@ -353,8 +349,7 @@
   ;;; ```
   (@interface func (export "options_open")
     (param $algorithm_type $algorithm_type)
-    (result $error $crypto_errno)
-    (result $handle $options)
+    (result $error (expected $options (error $crypto_errno)))
   )
 
   ;;; Destroy an options object.
@@ -362,7 +357,7 @@
   ;;; Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
   (@interface func (export "options_close")
     (param $handle $options)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Set or update an option.
@@ -375,7 +370,7 @@
     (param $name string)
     (param $value (@witx const_pointer u8))
     (param $value_len $size)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Set or update an integer option.
@@ -387,7 +382,7 @@
     (param $handle $options)
     (param $name string)
     (param $value u64)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Set or update a guest-allocated memory that the host can use or return data into.
@@ -400,7 +395,7 @@
     (param $name string)
     (param $buffer (@witx pointer u8))
     (param $buffer_len $size)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Return the length of an `array_output` object.
@@ -408,8 +403,7 @@
   ;;; This allows a guest to allocate a buffer of the correct size in order to copy the output of a function returning this object type.
   (@interface func (export "array_output_len")
     (param $array_output $array_output)
-    (result $error $crypto_errno)
-    (result $len $size)
+    (result $error (expected $size (error $crypto_errno)))
   )
 
   ;;; Copy the content of an `array_output` object into an application-allocated buffer.
@@ -431,8 +425,7 @@
     (param $array_output $array_output)
     (param $buf (@witx pointer u8))
     (param $buf_len $size)
-    (result $error $crypto_errno)
-    (result $len $size)
+    (result $error (expected $size (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -444,8 +437,7 @@
   ;;; This is also an optional import, meaning that the function may not even exist.
   (@interface func (export "secrets_manager_open")
     (param $options $opt_options)
-    (result $error $crypto_errno)
-    (result $handle $secrets_manager)
+    (result $error (expected $secrets_manager (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -455,7 +447,7 @@
   ;;; This is also an optional import, meaning that the function may not even exist.
   (@interface func (export "secrets_manager_close")
     (param $secrets_manager $secrets_manager)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -473,6 +465,8 @@
     (param $key_id (@witx const_pointer u8))
     (param $key_id_len $size)
     (param $key_version $version)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 )
+
+(typename $u64 u64)

--- a/witx/proposal_external_secrets.md
+++ b/witx/proposal_external_secrets.md
@@ -1,12 +1,12 @@
 # Types
-## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: Enum(`u16`)
+## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: `Variant`
 Error codes.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#crypto_errno.success" name="crypto_errno.success"></a> `success`
 Operation succeeded.
 
@@ -151,14 +151,14 @@ This error is returned when trying to build a key pair from a public key and a s
 - <a href="#crypto_errno.expired" name="crypto_errno.expired"></a> `expired`
 A managed key or secret expired and cannot be used any more.
 
-## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: Enum(`u16`)
+## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: `Variant`
 Encoding to use for importing or exporting a key pair.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#keypair_encoding.raw" name="keypair_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -171,14 +171,14 @@ PEM encoding.
 - <a href="#keypair_encoding.local" name="keypair_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: Enum(`u16`)
+## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: `Variant`
 Encoding to use for importing or exporting a public key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#publickey_encoding.raw" name="publickey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -197,14 +197,14 @@ Compressed SEC encoding.
 - <a href="#publickey_encoding.local" name="publickey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: Enum(`u16`)
+## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: `Variant`
 Encoding to use for importing or exporting a secret key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#secretkey_encoding.raw" name="secretkey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -223,52 +223,49 @@ Compressed SEC encoding.
 - <a href="#secretkey_encoding.local" name="secretkey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: Enum(`u16`)
+## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: `Variant`
 Encoding to use for importing or exporting a signature.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#signature_encoding.raw" name="signature_encoding.raw"></a> `raw`
 Raw bytes.
 
 - <a href="#signature_encoding.der" name="signature_encoding.der"></a> `der`
 DER encoding.
 
-## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: Enum(`u16`)
+## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: `Variant`
 An algorithm category.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#algorithm_type.signatures" name="algorithm_type.signatures"></a> `signatures`
 
 - <a href="#algorithm_type.symmetric" name="algorithm_type.symmetric"></a> `symmetric`
 
 - <a href="#algorithm_type.key_exchange" name="algorithm_type.key_exchange"></a> `key_exchange`
 
-## <a href="#version" name="version"></a> `version`: Int(`u64`)
+## <a href="#version" name="version"></a> `version`: `u64`
 Version of a managed key.
 
-A version can be an arbitrary `u64` integer, with the expection of some reserved values.
+A version can be an arbitrary [`u64`](#u64) integer, with the expection of some reserved values.
 
 Size: 8
 
 Alignment: 8
 
-### Consts
+### Constants
 - <a href="#version.unspecified" name="version.unspecified"></a> `unspecified`
-Key doesn't support versioning.
 
 - <a href="#version.latest" name="version.latest"></a> `latest`
-Use the latest version of a key.
 
 - <a href="#version.all" name="version.all"></a> `all`
-Perform an operation over all versions of a key.
 
 ## <a href="#size" name="size"></a> `size`: `usize`
 Size of a value.
@@ -284,7 +281,7 @@ Size: 8
 
 Alignment: 8
 
-## <a href="#array_output" name="array_output"></a> `array_output`
+## <a href="#array_output" name="array_output"></a> `array_output`: `Handle`
 Handle for functions returning output whose size may be large or not known in advance.
 
 An [`array_output`](#array_output) object contains a host-allocated byte array.
@@ -299,7 +296,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#options" name="options"></a> `options`
+## <a href="#options" name="options"></a> `options`: `Handle`
 A set of options.
 
 This type is used to set non-default parameters.
@@ -311,7 +308,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`
+## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`: `Handle`
 A handle to the optional secrets management facilities offered by a host.
 
 This is used to generate, retrieve and invalidate managed keys.
@@ -321,7 +318,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#keypair" name="keypair"></a> `keypair`
+## <a href="#keypair" name="keypair"></a> `keypair`: `Handle`
 A key pair.
 
 Size: 4
@@ -329,7 +326,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_state" name="signature_state"></a> `signature_state`
+## <a href="#signature_state" name="signature_state"></a> `signature_state`: `Handle`
 A state to absorb data to be signed.
 
 After a signature has been computed or verified, the state remains valid for further operations.
@@ -341,7 +338,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature" name="signature"></a> `signature`
+## <a href="#signature" name="signature"></a> `signature`: `Handle`
 A signature.
 
 Size: 4
@@ -349,7 +346,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#publickey" name="publickey"></a> `publickey`
+## <a href="#publickey" name="publickey"></a> `publickey`: `Handle`
 A public key, for key exchange and signature verification.
 
 Size: 4
@@ -357,7 +354,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secretkey" name="secretkey"></a> `secretkey`
+## <a href="#secretkey" name="secretkey"></a> `secretkey`: `Handle`
 A secret key, for key exchange mechanisms.
 
 Size: 4
@@ -365,7 +362,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`
+## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`: `Handle`
 A state to absorb signed data to be verified.
 
 Size: 4
@@ -373,7 +370,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`
+## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`: `Handle`
 A state to perform symmetric operations.
 
 The state is not reset nor invalidated after an option has been performed.
@@ -384,7 +381,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`
+## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`: `Handle`
 A symmetric key.
 
 The key can be imported from raw bytes, or can be a reference to a managed key.
@@ -396,7 +393,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`
+## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`: `Handle`
 An authentication tag.
 
 This is an object returned by functions computing authentication tags.
@@ -412,19 +409,19 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: Enum(`u8`)
+## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: `Variant`
 Options index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_options_u.some" name="opt_options_u.some"></a> `some`
 
 - <a href="#opt_options_u.none" name="opt_options_u.none"></a> `none`
 
-## <a href="#opt_options" name="opt_options"></a> `opt_options`: Union
+## <a href="#opt_options" name="opt_options"></a> `opt_options`: `Variant`
 An optional options set.
 
 This union simulates an `Option<Options>` type to make the [`options`](#options) parameter of some functions optional.
@@ -433,30 +430,28 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_options.some" name="opt_options.some"></a> `some`: [`options`](#options)
 
 - <a href="#opt_options.none" name="opt_options.none"></a> `none`
 
-## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: Enum(`u8`)
+## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: `Variant`
 Symmetric key index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_symmetric_key_u.some" name="opt_symmetric_key_u.some"></a> `some`
 
 - <a href="#opt_symmetric_key_u.none" name="opt_symmetric_key_u.none"></a> `none`
 
-## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: Union
+## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: `Variant`
 An optional symmetric key.
 
 This union simulates an `Option<SymmetricKey>` type to make the [`symmetric_key`](#symmetric_key) parameter of some functions optional.
@@ -465,16 +460,20 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_symmetric_key.some" name="opt_symmetric_key.some"></a> `some`: [`symmetric_key`](#symmetric_key)
 
 - <a href="#opt_symmetric_key.none" name="opt_symmetric_key.none"></a> `none`
+
+## <a href="#u64" name="u64"></a> `u64`: `u64`
+
+Size: 8
+
+Alignment: 8
 
 # Modules
 ## <a href="#wasi_ephemeral_crypto_common" name="wasi_ephemeral_crypto_common"></a> wasi_ephemeral_crypto_common
@@ -484,7 +483,7 @@ Alignment: 4
 
 ---
 
-#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> (crypto_errno, options)`
+#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> Result<options, crypto_errno>`
 Create a new object to set non-default options.
 
 Example usage:
@@ -501,14 +500,21 @@ options_close(options_handle)?;
 - <a href="#options_open.algorithm_type" name="options_open.algorithm_type"></a> `algorithm_type`: [`algorithm_type`](#algorithm_type)
 
 ##### Results
-- <a href="#options_open.error" name="options_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_open.error" name="options_open.error"></a> `error`: `Result<options, crypto_errno>`
 
-- <a href="#options_open.handle" name="options_open.handle"></a> `handle`: [`options`](#options)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_open.error.ok" name="options_open.error.ok"></a> `ok`: [`options`](#options)
+
+- <a href="#options_open.error.err" name="options_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> crypto_errno`
+#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> Result<(), crypto_errno>`
 Destroy an options object.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -517,12 +523,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#options_close.handle" name="options_close.handle"></a> `handle`: [`options`](#options)
 
 ##### Results
-- <a href="#options_close.error" name="options_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_close.error" name="options_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_close.error.ok" name="options_close.error.ok"></a> `ok`
+
+- <a href="#options_close.error.err" name="options_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> crypto_errno`
+#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> Result<(), crypto_errno>`
 Set or update an option.
 
 This is used to set algorithm-specific parameters, but also to provide credentials for the secrets management facilities, if required.
@@ -539,12 +554,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set.value_len" name="options_set.value_len"></a> `value_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set.error" name="options_set.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set.error" name="options_set.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set.error.ok" name="options_set.error.ok"></a> `ok`
+
+- <a href="#options_set.error.err" name="options_set.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> crypto_errno`
+#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> Result<(), crypto_errno>`
 Set or update an integer option.
 
 This is used to set algorithm-specific parameters.
@@ -559,12 +583,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_u64.value" name="options_set_u64.value"></a> `value`: `u64`
 
 ##### Results
-- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_u64.error.ok" name="options_set_u64.error.ok"></a> `ok`
+
+- <a href="#options_set_u64.error.err" name="options_set_u64.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> crypto_errno`
+#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> Result<(), crypto_errno>`
 Set or update a guest-allocated memory that the host can use or return data into.
 
 This is for example used to set the scratch buffer required by memory-hard functions.
@@ -581,12 +614,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_guest_buffer.buffer_len" name="options_set_guest_buffer.buffer_len"></a> `buffer_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_guest_buffer.error.ok" name="options_set_guest_buffer.error.ok"></a> `ok`
+
+- <a href="#options_set_guest_buffer.error.err" name="options_set_guest_buffer.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> (crypto_errno, size)`
+#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> Result<size, crypto_errno>`
 Return the length of an [`array_output`](#array_output) object.
 
 This allows a guest to allocate a buffer of the correct size in order to copy the output of a function returning this object type.
@@ -595,14 +637,21 @@ This allows a guest to allocate a buffer of the correct size in order to copy th
 - <a href="#array_output_len.array_output" name="array_output_len.array_output"></a> `array_output`: [`array_output`](#array_output)
 
 ##### Results
-- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_len.len" name="array_output_len.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_len.error.ok" name="array_output_len.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_len.error.err" name="array_output_len.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> (crypto_errno, size)`
+#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> Result<size, crypto_errno>`
 Copy the content of an [`array_output`](#array_output) object into an application-allocated buffer.
 
 Multiple calls to that function can be made in order to consume the data in a streaming fashion, if necessary.
@@ -627,14 +676,21 @@ array_output_pull(output_handle, &mut out)?;
 - <a href="#array_output_pull.buf_len" name="array_output_pull.buf_len"></a> `buf_len`: [`size`](#size)
 
 ##### Results
-- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_pull.len" name="array_output_pull.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_pull.error.ok" name="array_output_pull.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_pull.error.err" name="array_output_pull.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> (crypto_errno, secrets_manager)`
+#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> Result<secrets_manager, crypto_errno>`
 __(optional)__
 Create a context to use a secrets manager.
 
@@ -647,14 +703,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_open.options" name="secrets_manager_open.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: `Result<secrets_manager, crypto_errno>`
 
-- <a href="#secrets_manager_open.handle" name="secrets_manager_open.handle"></a> `handle`: [`secrets_manager`](#secrets_manager)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_open.error.ok" name="secrets_manager_open.error.ok"></a> `ok`: [`secrets_manager`](#secrets_manager)
+
+- <a href="#secrets_manager_open.error.err" name="secrets_manager_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> crypto_errno`
+#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> Result<(), crypto_errno>`
 __(optional)__
 Destroy a secrets manager context.
 
@@ -665,12 +728,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_close.secrets_manager" name="secrets_manager_close.secrets_manager"></a> `secrets_manager`: [`secrets_manager`](#secrets_manager)
 
 ##### Results
-- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_close.error.ok" name="secrets_manager_close.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_close.error.err" name="secrets_manager_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> crypto_errno`
+#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> Result<(), crypto_errno>`
 __(optional)__
 Invalidate a managed key or key pair given an identifier and a version.
 
@@ -692,7 +764,16 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_invalidate.key_version" name="secrets_manager_invalidate.key_version"></a> `key_version`: [`version`](#version)
 
 ##### Results
-- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_invalidate.error.ok" name="secrets_manager_invalidate.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_invalidate.error.err" name="secrets_manager_invalidate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 ## <a href="#wasi_ephemeral_crypto_exernal_secrets" name="wasi_ephemeral_crypto_exernal_secrets"></a> wasi_ephemeral_crypto_exernal_secrets
 ### Imports
@@ -701,7 +782,7 @@ This is an optional import, meaning that the function may not even exist.
 
 ---
 
-#### <a href="#external_secret_store" name="external_secret_store"></a> `external_secret_store(secrets_manager: secrets_manager, secret: ConstPointer<u8>, secret_len: size, expiration: timestamp, secret_id: Pointer<u8>, secret_id_max_len: size) -> crypto_errno`
+#### <a href="#external_secret_store" name="external_secret_store"></a> `external_secret_store(secrets_manager: secrets_manager, secret: ConstPointer<u8>, secret_len: size, expiration: timestamp, secret_id: Pointer<u8>, secret_id_max_len: size) -> Result<(), crypto_errno>`
 Store an external secret into the secrets manager.
 
 `$expiration` is the expiration date of the secret as a UNIX timestamp, in seconds.
@@ -726,12 +807,21 @@ If this function is not supported by the host the `$unsupported_feature` error i
 - <a href="#external_secret_store.secret_id_max_len" name="external_secret_store.secret_id_max_len"></a> `secret_id_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#external_secret_store.error" name="external_secret_store.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#external_secret_store.error" name="external_secret_store.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#external_secret_store.error.ok" name="external_secret_store.error.ok"></a> `ok`
+
+- <a href="#external_secret_store.error.err" name="external_secret_store.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#external_secret_replace" name="external_secret_replace"></a> `external_secret_replace(secrets_manager: secrets_manager, secret: ConstPointer<u8>, secret_len: size, expiration: timestamp, secret_id: ConstPointer<u8>, secret_id_len: size) -> (crypto_errno, version)`
+#### <a href="#external_secret_replace" name="external_secret_replace"></a> `external_secret_replace(secrets_manager: secrets_manager, secret: ConstPointer<u8>, secret_len: size, expiration: timestamp, secret_id: ConstPointer<u8>, secret_id_len: size) -> Result<version, crypto_errno>`
 Replace a managed external with a new version.
 
 `$expiration` is the expiration date of the secret as a UNIX timestamp, in seconds.
@@ -755,14 +845,21 @@ If this function is not supported by the host the `$unsupported_feature` error i
 - <a href="#external_secret_replace.secret_id_len" name="external_secret_replace.secret_id_len"></a> `secret_id_len`: [`size`](#size)
 
 ##### Results
-- <a href="#external_secret_replace.error" name="external_secret_replace.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#external_secret_replace.error" name="external_secret_replace.error"></a> `error`: `Result<version, crypto_errno>`
 
-- <a href="#external_secret_replace.secret_version" name="external_secret_replace.secret_version"></a> `secret_version`: [`version`](#version)
+###### Variant Layout
+- size: 16
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#external_secret_replace.error.ok" name="external_secret_replace.error.ok"></a> `ok`: [`version`](#version)
+
+- <a href="#external_secret_replace.error.err" name="external_secret_replace.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#external_secret_from_id" name="external_secret_from_id"></a> `external_secret_from_id(secrets_manager: secrets_manager, secret_id: ConstPointer<u8>, secret_id_len: size, secret_version: version) -> (crypto_errno, array_output)`
+#### <a href="#external_secret_from_id" name="external_secret_from_id"></a> `external_secret_from_id(secrets_manager: secrets_manager, secret_id: ConstPointer<u8>, secret_id_len: size, secret_version: version) -> Result<array_output, crypto_errno>`
 Get a copy of an external secret given an identifier and version.
 
 `secret_version` can be set to a version number, or to [`version.latest`](#version.latest) to retrieve the most recent version of a secret.
@@ -781,14 +878,21 @@ The function returns `$unsupported_feature` if this operation is not supported b
 - <a href="#external_secret_from_id.secret_version" name="external_secret_from_id.secret_version"></a> `secret_version`: [`version`](#version)
 
 ##### Results
-- <a href="#external_secret_from_id.error" name="external_secret_from_id.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#external_secret_from_id.error" name="external_secret_from_id.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#external_secret_from_id.secret" name="external_secret_from_id.secret"></a> `secret`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#external_secret_from_id.error.ok" name="external_secret_from_id.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#external_secret_from_id.error.err" name="external_secret_from_id.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#external_secret_invalidate" name="external_secret_invalidate"></a> `external_secret_invalidate(secrets_manager: secrets_manager, secret_id: ConstPointer<u8>, secret_id_len: size, secret_version: version) -> crypto_errno`
+#### <a href="#external_secret_invalidate" name="external_secret_invalidate"></a> `external_secret_invalidate(secrets_manager: secrets_manager, secret_id: ConstPointer<u8>, secret_id_len: size, secret_version: version) -> Result<(), crypto_errno>`
 Invalidate an external secret given an identifier and a version.
 
 This asks the secrets manager to delete or revoke a stored secret, a specific version of a secret.
@@ -807,12 +911,21 @@ The function returns `$unsupported_feature` if this operation is not supported b
 - <a href="#external_secret_invalidate.secret_version" name="external_secret_invalidate.secret_version"></a> `secret_version`: [`version`](#version)
 
 ##### Results
-- <a href="#external_secret_invalidate.error" name="external_secret_invalidate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#external_secret_invalidate.error" name="external_secret_invalidate.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#external_secret_invalidate.error.ok" name="external_secret_invalidate.error.ok"></a> `ok`
+
+- <a href="#external_secret_invalidate.error.err" name="external_secret_invalidate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#external_secret_encapsulate" name="external_secret_encapsulate"></a> `external_secret_encapsulate(secrets_manager: secrets_manager, secret: ConstPointer<u8>, secret_len: size, expiration: timestamp) -> (crypto_errno, array_output)`
+#### <a href="#external_secret_encapsulate" name="external_secret_encapsulate"></a> `external_secret_encapsulate(secrets_manager: secrets_manager, secret: ConstPointer<u8>, secret_len: size, expiration: timestamp) -> Result<array_output, crypto_errno>`
 Encrypt an external secret.
 
 Applications don't have access to the encryption key, and the secrets manager is free to choose any suitable algorithm.
@@ -831,14 +944,21 @@ On success, the ciphertext is returned.
 - <a href="#external_secret_encapsulate.expiration" name="external_secret_encapsulate.expiration"></a> `expiration`: [`timestamp`](#timestamp)
 
 ##### Results
-- <a href="#external_secret_encapsulate.error" name="external_secret_encapsulate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#external_secret_encapsulate.error" name="external_secret_encapsulate.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#external_secret_encapsulate.encrypted_secret" name="external_secret_encapsulate.encrypted_secret"></a> `encrypted_secret`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#external_secret_encapsulate.error.ok" name="external_secret_encapsulate.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#external_secret_encapsulate.error.err" name="external_secret_encapsulate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#external_secret_decapsulate" name="external_secret_decapsulate"></a> `external_secret_decapsulate(secrets_manager: secrets_manager, encrypted_secret: ConstPointer<u8>, encrypted_secret_len: size) -> (crypto_errno, array_output)`
+#### <a href="#external_secret_decapsulate" name="external_secret_decapsulate"></a> `external_secret_decapsulate(secrets_manager: secrets_manager, encrypted_secret: ConstPointer<u8>, encrypted_secret_len: size) -> Result<array_output, crypto_errno>`
 Decrypt an external secret previously encrypted by the secrets manager.
 
 Returns the original secret if the ciphertext is valid.
@@ -853,7 +973,15 @@ Returns `$verification_failed` if the ciphertext format is invalid or if its aut
 - <a href="#external_secret_decapsulate.encrypted_secret_len" name="external_secret_decapsulate.encrypted_secret_len"></a> `encrypted_secret_len`: [`size`](#size)
 
 ##### Results
-- <a href="#external_secret_decapsulate.error" name="external_secret_decapsulate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#external_secret_decapsulate.error" name="external_secret_decapsulate.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#external_secret_decapsulate.secret" name="external_secret_decapsulate.secret"></a> `secret`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#external_secret_decapsulate.error.ok" name="external_secret_decapsulate.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#external_secret_decapsulate.error.err" name="external_secret_decapsulate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
+
 

--- a/witx/proposal_external_secrets.witx
+++ b/witx/proposal_external_secrets.witx
@@ -29,7 +29,7 @@
     (param $expiration $timestamp)
     (param $secret_id (@witx pointer u8))
     (param $secret_id_max_len $size)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Replace a managed external with a new version.
@@ -47,8 +47,7 @@
     (param $expiration $timestamp)
     (param $secret_id (@witx const_pointer u8))
     (param $secret_id_len $size)
-    (result $error $crypto_errno)
-    (result $secret_version $version)
+    (result $error (expected $version (error $crypto_errno)))
   )
 
   ;;; Get a copy of an external secret given an identifier and version.
@@ -63,8 +62,7 @@
     (param $secret_id (@witx const_pointer u8))
     (param $secret_id_len $size)
     (param $secret_version $version)
-    (result $error $crypto_errno)
-    (result $secret $array_output)
+    (result $error (expected $array_output (error $crypto_errno)))
   )
 
   ;;; Invalidate an external secret given an identifier and a version.
@@ -79,7 +77,7 @@
     (param $secret_id (@witx const_pointer u8))
     (param $secret_id_len $size)
     (param $secret_version $version)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Encrypt an external secret.
@@ -94,8 +92,7 @@
     (param $secret (@witx const_pointer u8))
     (param $secret_len $size)
     (param $expiration $timestamp)
-    (result $error $crypto_errno)
-    (result $encrypted_secret $array_output)
+    (result $error (expected $array_output (error $crypto_errno)))
   )
 
   ;;; Decrypt an external secret previously encrypted by the secrets manager.
@@ -107,7 +104,6 @@
     (param $secrets_manager $secrets_manager)
     (param $encrypted_secret (@witx const_pointer u8))
     (param $encrypted_secret_len $size)
-    (result $error $crypto_errno)
-    (result $secret $array_output)
+    (result $error (expected $array_output (error $crypto_errno)))
   )
 )

--- a/witx/proposal_kx.md
+++ b/witx/proposal_kx.md
@@ -1,12 +1,12 @@
 # Types
-## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: Enum(`u16`)
+## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: `Variant`
 Error codes.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#crypto_errno.success" name="crypto_errno.success"></a> `success`
 Operation succeeded.
 
@@ -151,14 +151,14 @@ This error is returned when trying to build a key pair from a public key and a s
 - <a href="#crypto_errno.expired" name="crypto_errno.expired"></a> `expired`
 A managed key or secret expired and cannot be used any more.
 
-## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: Enum(`u16`)
+## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: `Variant`
 Encoding to use for importing or exporting a key pair.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#keypair_encoding.raw" name="keypair_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -171,14 +171,14 @@ PEM encoding.
 - <a href="#keypair_encoding.local" name="keypair_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: Enum(`u16`)
+## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: `Variant`
 Encoding to use for importing or exporting a public key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#publickey_encoding.raw" name="publickey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -197,14 +197,14 @@ Compressed SEC encoding.
 - <a href="#publickey_encoding.local" name="publickey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: Enum(`u16`)
+## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: `Variant`
 Encoding to use for importing or exporting a secret key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#secretkey_encoding.raw" name="secretkey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -223,52 +223,49 @@ Compressed SEC encoding.
 - <a href="#secretkey_encoding.local" name="secretkey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: Enum(`u16`)
+## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: `Variant`
 Encoding to use for importing or exporting a signature.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#signature_encoding.raw" name="signature_encoding.raw"></a> `raw`
 Raw bytes.
 
 - <a href="#signature_encoding.der" name="signature_encoding.der"></a> `der`
 DER encoding.
 
-## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: Enum(`u16`)
+## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: `Variant`
 An algorithm category.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#algorithm_type.signatures" name="algorithm_type.signatures"></a> `signatures`
 
 - <a href="#algorithm_type.symmetric" name="algorithm_type.symmetric"></a> `symmetric`
 
 - <a href="#algorithm_type.key_exchange" name="algorithm_type.key_exchange"></a> `key_exchange`
 
-## <a href="#version" name="version"></a> `version`: Int(`u64`)
+## <a href="#version" name="version"></a> `version`: `u64`
 Version of a managed key.
 
-A version can be an arbitrary `u64` integer, with the expection of some reserved values.
+A version can be an arbitrary [`u64`](#u64) integer, with the expection of some reserved values.
 
 Size: 8
 
 Alignment: 8
 
-### Consts
+### Constants
 - <a href="#version.unspecified" name="version.unspecified"></a> `unspecified`
-Key doesn't support versioning.
 
 - <a href="#version.latest" name="version.latest"></a> `latest`
-Use the latest version of a key.
 
 - <a href="#version.all" name="version.all"></a> `all`
-Perform an operation over all versions of a key.
 
 ## <a href="#size" name="size"></a> `size`: `usize`
 Size of a value.
@@ -284,7 +281,7 @@ Size: 8
 
 Alignment: 8
 
-## <a href="#array_output" name="array_output"></a> `array_output`
+## <a href="#array_output" name="array_output"></a> `array_output`: `Handle`
 Handle for functions returning output whose size may be large or not known in advance.
 
 An [`array_output`](#array_output) object contains a host-allocated byte array.
@@ -299,7 +296,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#options" name="options"></a> `options`
+## <a href="#options" name="options"></a> `options`: `Handle`
 A set of options.
 
 This type is used to set non-default parameters.
@@ -311,7 +308,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`
+## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`: `Handle`
 A handle to the optional secrets management facilities offered by a host.
 
 This is used to generate, retrieve and invalidate managed keys.
@@ -321,7 +318,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#keypair" name="keypair"></a> `keypair`
+## <a href="#keypair" name="keypair"></a> `keypair`: `Handle`
 A key pair.
 
 Size: 4
@@ -329,7 +326,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_state" name="signature_state"></a> `signature_state`
+## <a href="#signature_state" name="signature_state"></a> `signature_state`: `Handle`
 A state to absorb data to be signed.
 
 After a signature has been computed or verified, the state remains valid for further operations.
@@ -341,7 +338,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature" name="signature"></a> `signature`
+## <a href="#signature" name="signature"></a> `signature`: `Handle`
 A signature.
 
 Size: 4
@@ -349,7 +346,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#publickey" name="publickey"></a> `publickey`
+## <a href="#publickey" name="publickey"></a> `publickey`: `Handle`
 A public key, for key exchange and signature verification.
 
 Size: 4
@@ -357,7 +354,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secretkey" name="secretkey"></a> `secretkey`
+## <a href="#secretkey" name="secretkey"></a> `secretkey`: `Handle`
 A secret key, for key exchange mechanisms.
 
 Size: 4
@@ -365,7 +362,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`
+## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`: `Handle`
 A state to absorb signed data to be verified.
 
 Size: 4
@@ -373,7 +370,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`
+## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`: `Handle`
 A state to perform symmetric operations.
 
 The state is not reset nor invalidated after an option has been performed.
@@ -384,7 +381,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`
+## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`: `Handle`
 A symmetric key.
 
 The key can be imported from raw bytes, or can be a reference to a managed key.
@@ -396,7 +393,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`
+## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`: `Handle`
 An authentication tag.
 
 This is an object returned by functions computing authentication tags.
@@ -412,19 +409,19 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: Enum(`u8`)
+## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: `Variant`
 Options index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_options_u.some" name="opt_options_u.some"></a> `some`
 
 - <a href="#opt_options_u.none" name="opt_options_u.none"></a> `none`
 
-## <a href="#opt_options" name="opt_options"></a> `opt_options`: Union
+## <a href="#opt_options" name="opt_options"></a> `opt_options`: `Variant`
 An optional options set.
 
 This union simulates an `Option<Options>` type to make the [`options`](#options) parameter of some functions optional.
@@ -433,30 +430,28 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_options.some" name="opt_options.some"></a> `some`: [`options`](#options)
 
 - <a href="#opt_options.none" name="opt_options.none"></a> `none`
 
-## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: Enum(`u8`)
+## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: `Variant`
 Symmetric key index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_symmetric_key_u.some" name="opt_symmetric_key_u.some"></a> `some`
 
 - <a href="#opt_symmetric_key_u.none" name="opt_symmetric_key_u.none"></a> `none`
 
-## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: Union
+## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: `Variant`
 An optional symmetric key.
 
 This union simulates an `Option<SymmetricKey>` type to make the [`symmetric_key`](#symmetric_key) parameter of some functions optional.
@@ -465,16 +460,20 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_symmetric_key.some" name="opt_symmetric_key.some"></a> `some`: [`symmetric_key`](#symmetric_key)
 
 - <a href="#opt_symmetric_key.none" name="opt_symmetric_key.none"></a> `none`
+
+## <a href="#u64" name="u64"></a> `u64`: `u64`
+
+Size: 8
+
+Alignment: 8
 
 ## <a href="#kx_keypair" name="kx_keypair"></a> `kx_keypair`: [`keypair`](#keypair)
 `$kx_keypair` is just an alias for `$keypair`
@@ -511,7 +510,7 @@ Alignment: 4
 
 ---
 
-#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> (crypto_errno, options)`
+#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> Result<options, crypto_errno>`
 Create a new object to set non-default options.
 
 Example usage:
@@ -528,14 +527,21 @@ options_close(options_handle)?;
 - <a href="#options_open.algorithm_type" name="options_open.algorithm_type"></a> `algorithm_type`: [`algorithm_type`](#algorithm_type)
 
 ##### Results
-- <a href="#options_open.error" name="options_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_open.error" name="options_open.error"></a> `error`: `Result<options, crypto_errno>`
 
-- <a href="#options_open.handle" name="options_open.handle"></a> `handle`: [`options`](#options)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_open.error.ok" name="options_open.error.ok"></a> `ok`: [`options`](#options)
+
+- <a href="#options_open.error.err" name="options_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> crypto_errno`
+#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> Result<(), crypto_errno>`
 Destroy an options object.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -544,12 +550,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#options_close.handle" name="options_close.handle"></a> `handle`: [`options`](#options)
 
 ##### Results
-- <a href="#options_close.error" name="options_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_close.error" name="options_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_close.error.ok" name="options_close.error.ok"></a> `ok`
+
+- <a href="#options_close.error.err" name="options_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> crypto_errno`
+#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> Result<(), crypto_errno>`
 Set or update an option.
 
 This is used to set algorithm-specific parameters, but also to provide credentials for the secrets management facilities, if required.
@@ -566,12 +581,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set.value_len" name="options_set.value_len"></a> `value_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set.error" name="options_set.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set.error" name="options_set.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set.error.ok" name="options_set.error.ok"></a> `ok`
+
+- <a href="#options_set.error.err" name="options_set.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> crypto_errno`
+#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> Result<(), crypto_errno>`
 Set or update an integer option.
 
 This is used to set algorithm-specific parameters.
@@ -586,12 +610,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_u64.value" name="options_set_u64.value"></a> `value`: `u64`
 
 ##### Results
-- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_u64.error.ok" name="options_set_u64.error.ok"></a> `ok`
+
+- <a href="#options_set_u64.error.err" name="options_set_u64.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> crypto_errno`
+#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> Result<(), crypto_errno>`
 Set or update a guest-allocated memory that the host can use or return data into.
 
 This is for example used to set the scratch buffer required by memory-hard functions.
@@ -608,12 +641,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_guest_buffer.buffer_len" name="options_set_guest_buffer.buffer_len"></a> `buffer_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_guest_buffer.error.ok" name="options_set_guest_buffer.error.ok"></a> `ok`
+
+- <a href="#options_set_guest_buffer.error.err" name="options_set_guest_buffer.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> (crypto_errno, size)`
+#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> Result<size, crypto_errno>`
 Return the length of an [`array_output`](#array_output) object.
 
 This allows a guest to allocate a buffer of the correct size in order to copy the output of a function returning this object type.
@@ -622,14 +664,21 @@ This allows a guest to allocate a buffer of the correct size in order to copy th
 - <a href="#array_output_len.array_output" name="array_output_len.array_output"></a> `array_output`: [`array_output`](#array_output)
 
 ##### Results
-- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_len.len" name="array_output_len.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_len.error.ok" name="array_output_len.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_len.error.err" name="array_output_len.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> (crypto_errno, size)`
+#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> Result<size, crypto_errno>`
 Copy the content of an [`array_output`](#array_output) object into an application-allocated buffer.
 
 Multiple calls to that function can be made in order to consume the data in a streaming fashion, if necessary.
@@ -654,14 +703,21 @@ array_output_pull(output_handle, &mut out)?;
 - <a href="#array_output_pull.buf_len" name="array_output_pull.buf_len"></a> `buf_len`: [`size`](#size)
 
 ##### Results
-- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_pull.len" name="array_output_pull.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_pull.error.ok" name="array_output_pull.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_pull.error.err" name="array_output_pull.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> (crypto_errno, secrets_manager)`
+#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> Result<secrets_manager, crypto_errno>`
 __(optional)__
 Create a context to use a secrets manager.
 
@@ -674,14 +730,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_open.options" name="secrets_manager_open.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: `Result<secrets_manager, crypto_errno>`
 
-- <a href="#secrets_manager_open.handle" name="secrets_manager_open.handle"></a> `handle`: [`secrets_manager`](#secrets_manager)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_open.error.ok" name="secrets_manager_open.error.ok"></a> `ok`: [`secrets_manager`](#secrets_manager)
+
+- <a href="#secrets_manager_open.error.err" name="secrets_manager_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> crypto_errno`
+#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> Result<(), crypto_errno>`
 __(optional)__
 Destroy a secrets manager context.
 
@@ -692,12 +755,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_close.secrets_manager" name="secrets_manager_close.secrets_manager"></a> `secrets_manager`: [`secrets_manager`](#secrets_manager)
 
 ##### Results
-- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_close.error.ok" name="secrets_manager_close.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_close.error.err" name="secrets_manager_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> crypto_errno`
+#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> Result<(), crypto_errno>`
 __(optional)__
 Invalidate a managed key or key pair given an identifier and a version.
 
@@ -719,7 +791,16 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_invalidate.key_version" name="secrets_manager_invalidate.key_version"></a> `key_version`: [`version`](#version)
 
 ##### Results
-- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_invalidate.error.ok" name="secrets_manager_invalidate.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_invalidate.error.err" name="secrets_manager_invalidate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 ## <a href="#wasi_ephemeral_crypto_kx" name="wasi_ephemeral_crypto_kx"></a> wasi_ephemeral_crypto_kx
 ### Imports
@@ -728,7 +809,7 @@ This is an optional import, meaning that the function may not even exist.
 
 ---
 
-#### <a href="#kx_dh" name="kx_dh"></a> `kx_dh(pk: publickey, sk: secretkey) -> (crypto_errno, array_output)`
+#### <a href="#kx_dh" name="kx_dh"></a> `kx_dh(pk: publickey, sk: secretkey) -> Result<array_output, crypto_errno>`
 Perform a simple Diffie-Hellman key exchange.
 
 Both keys must be of the same type, or else the `$crypto_errno.incompatible_keys` error is returned.
@@ -742,14 +823,21 @@ Otherwide, a raw shared key is returned, and can be imported as a symmetric key.
 - <a href="#kx_dh.sk" name="kx_dh.sk"></a> `sk`: [`secretkey`](#secretkey)
 
 ##### Results
-- <a href="#kx_dh.error" name="kx_dh.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#kx_dh.error" name="kx_dh.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#kx_dh.shared_secret" name="kx_dh.shared_secret"></a> `shared_secret`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#kx_dh.error.ok" name="kx_dh.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#kx_dh.error.err" name="kx_dh.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#kx_encapsulate" name="kx_encapsulate"></a> `kx_encapsulate(pk: publickey) -> (crypto_errno, array_output, array_output)`
+#### <a href="#kx_encapsulate" name="kx_encapsulate"></a> `kx_encapsulate(pk: publickey) -> Result<(array_output, array_output), crypto_errno>`
 Create a shared secret and encrypt it for the given public key.
 
 This operation is only compatible with specific algorithms.
@@ -761,16 +849,30 @@ On success, both the shared secret and its encrypted version are returned.
 - <a href="#kx_encapsulate.pk" name="kx_encapsulate.pk"></a> `pk`: [`publickey`](#publickey)
 
 ##### Results
-- <a href="#kx_encapsulate.error" name="kx_encapsulate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#kx_encapsulate.error" name="kx_encapsulate.error"></a> `error`: `Result<(array_output, array_output), crypto_errno>`
 
-- <a href="#kx_encapsulate.secret" name="kx_encapsulate.secret"></a> `secret`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 12
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#kx_encapsulate.error.ok" name="kx_encapsulate.error.ok"></a> `ok`: `(array_output, array_output)`
 
-- <a href="#kx_encapsulate.encapsulated_secret" name="kx_encapsulate.encapsulated_secret"></a> `encapsulated_secret`: [`array_output`](#array_output)
+####### Record members
+- <a href="#kx_encapsulate.error.ok.0" name="kx_encapsulate.error.ok.0"></a> `0`: [`array_output`](#array_output)
+
+Offset: 0
+
+- <a href="#kx_encapsulate.error.ok.1" name="kx_encapsulate.error.ok.1"></a> `1`: [`array_output`](#array_output)
+
+Offset: 4
+
+- <a href="#kx_encapsulate.error.err" name="kx_encapsulate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#kx_decapsulate" name="kx_decapsulate"></a> `kx_decapsulate(sk: secretkey, encapsulated_secret: ConstPointer<u8>, encapsulated_secret_len: size) -> (crypto_errno, array_output)`
+#### <a href="#kx_decapsulate" name="kx_decapsulate"></a> `kx_decapsulate(sk: secretkey, encapsulated_secret: ConstPointer<u8>, encapsulated_secret_len: size) -> Result<array_output, crypto_errno>`
 Decapsulate an encapsulated secret crated with [`kx_encapsulate`](#kx_encapsulate)
 
 Return the secret, or `$crypto_errno.verification_failed` on error.
@@ -783,7 +885,15 @@ Return the secret, or `$crypto_errno.verification_failed` on error.
 - <a href="#kx_decapsulate.encapsulated_secret_len" name="kx_decapsulate.encapsulated_secret_len"></a> `encapsulated_secret_len`: [`size`](#size)
 
 ##### Results
-- <a href="#kx_decapsulate.error" name="kx_decapsulate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#kx_decapsulate.error" name="kx_decapsulate.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#kx_decapsulate.secret" name="kx_decapsulate.secret"></a> `secret`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#kx_decapsulate.error.ok" name="kx_decapsulate.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#kx_decapsulate.error.err" name="kx_decapsulate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
+
 

--- a/witx/proposal_kx.witx
+++ b/witx/proposal_kx.witx
@@ -30,8 +30,7 @@
   (@interface func (export "kx_dh")
     (param $pk $publickey)
     (param $sk $secretkey)
-    (result $error $crypto_errno)
-    (result $shared_secret $array_output)
+    (result $error (expected $array_output (error $crypto_errno)))
   )
 
   ;;; Create a shared secret and encrypt it for the given public key.
@@ -42,9 +41,7 @@
   ;;; On success, both the shared secret and its encrypted version are returned.
   (@interface func (export "kx_encapsulate")
     (param $pk $publickey)
-    (result $error $crypto_errno)
-    (result $secret $array_output)
-    (result $encapsulated_secret $array_output)
+    (result $error (expected (tuple $array_output $array_output) (error $crypto_errno)))
   )
 
   ;;; Decapsulate an encapsulated secret crated with `kx_encapsulate`
@@ -54,7 +51,6 @@
     (param $sk $secretkey)
     (param $encapsulated_secret (@witx const_pointer u8))
     (param $encapsulated_secret_len $size)
-    (result $error $crypto_errno)
-    (result $secret $array_output)
+    (result $error (expected $array_output (error $crypto_errno)))
   )
 )

--- a/witx/proposal_signatures.md
+++ b/witx/proposal_signatures.md
@@ -1,12 +1,12 @@
 # Types
-## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: Enum(`u16`)
+## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: `Variant`
 Error codes.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#crypto_errno.success" name="crypto_errno.success"></a> `success`
 Operation succeeded.
 
@@ -151,14 +151,14 @@ This error is returned when trying to build a key pair from a public key and a s
 - <a href="#crypto_errno.expired" name="crypto_errno.expired"></a> `expired`
 A managed key or secret expired and cannot be used any more.
 
-## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: Enum(`u16`)
+## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: `Variant`
 Encoding to use for importing or exporting a key pair.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#keypair_encoding.raw" name="keypair_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -171,14 +171,14 @@ PEM encoding.
 - <a href="#keypair_encoding.local" name="keypair_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: Enum(`u16`)
+## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: `Variant`
 Encoding to use for importing or exporting a public key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#publickey_encoding.raw" name="publickey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -197,14 +197,14 @@ Compressed SEC encoding.
 - <a href="#publickey_encoding.local" name="publickey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: Enum(`u16`)
+## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: `Variant`
 Encoding to use for importing or exporting a secret key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#secretkey_encoding.raw" name="secretkey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -223,52 +223,49 @@ Compressed SEC encoding.
 - <a href="#secretkey_encoding.local" name="secretkey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: Enum(`u16`)
+## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: `Variant`
 Encoding to use for importing or exporting a signature.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#signature_encoding.raw" name="signature_encoding.raw"></a> `raw`
 Raw bytes.
 
 - <a href="#signature_encoding.der" name="signature_encoding.der"></a> `der`
 DER encoding.
 
-## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: Enum(`u16`)
+## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: `Variant`
 An algorithm category.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#algorithm_type.signatures" name="algorithm_type.signatures"></a> `signatures`
 
 - <a href="#algorithm_type.symmetric" name="algorithm_type.symmetric"></a> `symmetric`
 
 - <a href="#algorithm_type.key_exchange" name="algorithm_type.key_exchange"></a> `key_exchange`
 
-## <a href="#version" name="version"></a> `version`: Int(`u64`)
+## <a href="#version" name="version"></a> `version`: `u64`
 Version of a managed key.
 
-A version can be an arbitrary `u64` integer, with the expection of some reserved values.
+A version can be an arbitrary [`u64`](#u64) integer, with the expection of some reserved values.
 
 Size: 8
 
 Alignment: 8
 
-### Consts
+### Constants
 - <a href="#version.unspecified" name="version.unspecified"></a> `unspecified`
-Key doesn't support versioning.
 
 - <a href="#version.latest" name="version.latest"></a> `latest`
-Use the latest version of a key.
 
 - <a href="#version.all" name="version.all"></a> `all`
-Perform an operation over all versions of a key.
 
 ## <a href="#size" name="size"></a> `size`: `usize`
 Size of a value.
@@ -284,7 +281,7 @@ Size: 8
 
 Alignment: 8
 
-## <a href="#array_output" name="array_output"></a> `array_output`
+## <a href="#array_output" name="array_output"></a> `array_output`: `Handle`
 Handle for functions returning output whose size may be large or not known in advance.
 
 An [`array_output`](#array_output) object contains a host-allocated byte array.
@@ -299,7 +296,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#options" name="options"></a> `options`
+## <a href="#options" name="options"></a> `options`: `Handle`
 A set of options.
 
 This type is used to set non-default parameters.
@@ -311,7 +308,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`
+## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`: `Handle`
 A handle to the optional secrets management facilities offered by a host.
 
 This is used to generate, retrieve and invalidate managed keys.
@@ -321,7 +318,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#keypair" name="keypair"></a> `keypair`
+## <a href="#keypair" name="keypair"></a> `keypair`: `Handle`
 A key pair.
 
 Size: 4
@@ -329,7 +326,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_state" name="signature_state"></a> `signature_state`
+## <a href="#signature_state" name="signature_state"></a> `signature_state`: `Handle`
 A state to absorb data to be signed.
 
 After a signature has been computed or verified, the state remains valid for further operations.
@@ -341,7 +338,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature" name="signature"></a> `signature`
+## <a href="#signature" name="signature"></a> `signature`: `Handle`
 A signature.
 
 Size: 4
@@ -349,7 +346,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#publickey" name="publickey"></a> `publickey`
+## <a href="#publickey" name="publickey"></a> `publickey`: `Handle`
 A public key, for key exchange and signature verification.
 
 Size: 4
@@ -357,7 +354,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secretkey" name="secretkey"></a> `secretkey`
+## <a href="#secretkey" name="secretkey"></a> `secretkey`: `Handle`
 A secret key, for key exchange mechanisms.
 
 Size: 4
@@ -365,7 +362,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`
+## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`: `Handle`
 A state to absorb signed data to be verified.
 
 Size: 4
@@ -373,7 +370,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`
+## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`: `Handle`
 A state to perform symmetric operations.
 
 The state is not reset nor invalidated after an option has been performed.
@@ -384,7 +381,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`
+## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`: `Handle`
 A symmetric key.
 
 The key can be imported from raw bytes, or can be a reference to a managed key.
@@ -396,7 +393,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`
+## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`: `Handle`
 An authentication tag.
 
 This is an object returned by functions computing authentication tags.
@@ -412,19 +409,19 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: Enum(`u8`)
+## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: `Variant`
 Options index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_options_u.some" name="opt_options_u.some"></a> `some`
 
 - <a href="#opt_options_u.none" name="opt_options_u.none"></a> `none`
 
-## <a href="#opt_options" name="opt_options"></a> `opt_options`: Union
+## <a href="#opt_options" name="opt_options"></a> `opt_options`: `Variant`
 An optional options set.
 
 This union simulates an `Option<Options>` type to make the [`options`](#options) parameter of some functions optional.
@@ -433,30 +430,28 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_options.some" name="opt_options.some"></a> `some`: [`options`](#options)
 
 - <a href="#opt_options.none" name="opt_options.none"></a> `none`
 
-## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: Enum(`u8`)
+## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: `Variant`
 Symmetric key index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_symmetric_key_u.some" name="opt_symmetric_key_u.some"></a> `some`
 
 - <a href="#opt_symmetric_key_u.none" name="opt_symmetric_key_u.none"></a> `none`
 
-## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: Union
+## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: `Variant`
 An optional symmetric key.
 
 This union simulates an `Option<SymmetricKey>` type to make the [`symmetric_key`](#symmetric_key) parameter of some functions optional.
@@ -465,16 +460,20 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_symmetric_key.some" name="opt_symmetric_key.some"></a> `some`: [`symmetric_key`](#symmetric_key)
 
 - <a href="#opt_symmetric_key.none" name="opt_symmetric_key.none"></a> `none`
+
+## <a href="#u64" name="u64"></a> `u64`: `u64`
+
+Size: 8
+
+Alignment: 8
 
 ## <a href="#signature_keypair" name="signature_keypair"></a> `signature_keypair`: [`keypair`](#keypair)
 `$signature_keypair` is just an alias for `$keypair`
@@ -511,7 +510,7 @@ Alignment: 4
 
 ---
 
-#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> (crypto_errno, options)`
+#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> Result<options, crypto_errno>`
 Create a new object to set non-default options.
 
 Example usage:
@@ -528,14 +527,21 @@ options_close(options_handle)?;
 - <a href="#options_open.algorithm_type" name="options_open.algorithm_type"></a> `algorithm_type`: [`algorithm_type`](#algorithm_type)
 
 ##### Results
-- <a href="#options_open.error" name="options_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_open.error" name="options_open.error"></a> `error`: `Result<options, crypto_errno>`
 
-- <a href="#options_open.handle" name="options_open.handle"></a> `handle`: [`options`](#options)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_open.error.ok" name="options_open.error.ok"></a> `ok`: [`options`](#options)
+
+- <a href="#options_open.error.err" name="options_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> crypto_errno`
+#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> Result<(), crypto_errno>`
 Destroy an options object.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -544,12 +550,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#options_close.handle" name="options_close.handle"></a> `handle`: [`options`](#options)
 
 ##### Results
-- <a href="#options_close.error" name="options_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_close.error" name="options_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_close.error.ok" name="options_close.error.ok"></a> `ok`
+
+- <a href="#options_close.error.err" name="options_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> crypto_errno`
+#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> Result<(), crypto_errno>`
 Set or update an option.
 
 This is used to set algorithm-specific parameters, but also to provide credentials for the secrets management facilities, if required.
@@ -566,12 +581,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set.value_len" name="options_set.value_len"></a> `value_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set.error" name="options_set.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set.error" name="options_set.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set.error.ok" name="options_set.error.ok"></a> `ok`
+
+- <a href="#options_set.error.err" name="options_set.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> crypto_errno`
+#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> Result<(), crypto_errno>`
 Set or update an integer option.
 
 This is used to set algorithm-specific parameters.
@@ -586,12 +610,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_u64.value" name="options_set_u64.value"></a> `value`: `u64`
 
 ##### Results
-- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_u64.error.ok" name="options_set_u64.error.ok"></a> `ok`
+
+- <a href="#options_set_u64.error.err" name="options_set_u64.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> crypto_errno`
+#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> Result<(), crypto_errno>`
 Set or update a guest-allocated memory that the host can use or return data into.
 
 This is for example used to set the scratch buffer required by memory-hard functions.
@@ -608,12 +641,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_guest_buffer.buffer_len" name="options_set_guest_buffer.buffer_len"></a> `buffer_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_guest_buffer.error.ok" name="options_set_guest_buffer.error.ok"></a> `ok`
+
+- <a href="#options_set_guest_buffer.error.err" name="options_set_guest_buffer.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> (crypto_errno, size)`
+#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> Result<size, crypto_errno>`
 Return the length of an [`array_output`](#array_output) object.
 
 This allows a guest to allocate a buffer of the correct size in order to copy the output of a function returning this object type.
@@ -622,14 +664,21 @@ This allows a guest to allocate a buffer of the correct size in order to copy th
 - <a href="#array_output_len.array_output" name="array_output_len.array_output"></a> `array_output`: [`array_output`](#array_output)
 
 ##### Results
-- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_len.len" name="array_output_len.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_len.error.ok" name="array_output_len.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_len.error.err" name="array_output_len.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> (crypto_errno, size)`
+#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> Result<size, crypto_errno>`
 Copy the content of an [`array_output`](#array_output) object into an application-allocated buffer.
 
 Multiple calls to that function can be made in order to consume the data in a streaming fashion, if necessary.
@@ -654,14 +703,21 @@ array_output_pull(output_handle, &mut out)?;
 - <a href="#array_output_pull.buf_len" name="array_output_pull.buf_len"></a> `buf_len`: [`size`](#size)
 
 ##### Results
-- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_pull.len" name="array_output_pull.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_pull.error.ok" name="array_output_pull.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_pull.error.err" name="array_output_pull.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> (crypto_errno, secrets_manager)`
+#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> Result<secrets_manager, crypto_errno>`
 __(optional)__
 Create a context to use a secrets manager.
 
@@ -674,14 +730,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_open.options" name="secrets_manager_open.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: `Result<secrets_manager, crypto_errno>`
 
-- <a href="#secrets_manager_open.handle" name="secrets_manager_open.handle"></a> `handle`: [`secrets_manager`](#secrets_manager)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_open.error.ok" name="secrets_manager_open.error.ok"></a> `ok`: [`secrets_manager`](#secrets_manager)
+
+- <a href="#secrets_manager_open.error.err" name="secrets_manager_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> crypto_errno`
+#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> Result<(), crypto_errno>`
 __(optional)__
 Destroy a secrets manager context.
 
@@ -692,12 +755,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_close.secrets_manager" name="secrets_manager_close.secrets_manager"></a> `secrets_manager`: [`secrets_manager`](#secrets_manager)
 
 ##### Results
-- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_close.error.ok" name="secrets_manager_close.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_close.error.err" name="secrets_manager_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> crypto_errno`
+#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> Result<(), crypto_errno>`
 __(optional)__
 Invalidate a managed key or key pair given an identifier and a version.
 
@@ -719,7 +791,16 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_invalidate.key_version" name="secrets_manager_invalidate.key_version"></a> `key_version`: [`version`](#version)
 
 ##### Results
-- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_invalidate.error.ok" name="secrets_manager_invalidate.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_invalidate.error.err" name="secrets_manager_invalidate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 ## <a href="#wasi_ephemeral_crypto_asymmetric_common" name="wasi_ephemeral_crypto_asymmetric_common"></a> wasi_ephemeral_crypto_asymmetric_common
 ### Imports
@@ -728,7 +809,7 @@ This is an optional import, meaning that the function may not even exist.
 
 ---
 
-#### <a href="#keypair_generate" name="keypair_generate"></a> `keypair_generate(algorithm_type: algorithm_type, algorithm: string, options: opt_options) -> (crypto_errno, keypair)`
+#### <a href="#keypair_generate" name="keypair_generate"></a> `keypair_generate(algorithm_type: algorithm_type, algorithm: string, options: opt_options) -> Result<keypair, crypto_errno>`
 Generate a new key pair.
 
 Internally, a key pair stores the supplied algorithm and optional parameters.
@@ -756,14 +837,21 @@ let kp_handle = ctx.keypair_generate(AlgorithmType::Signatures, "RSA_PKCS1_2048_
 - <a href="#keypair_generate.options" name="keypair_generate.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#keypair_generate.error" name="keypair_generate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_generate.error" name="keypair_generate.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_generate.handle" name="keypair_generate.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_generate.error.ok" name="keypair_generate.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_generate.error.err" name="keypair_generate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_import" name="keypair_import"></a> `keypair_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: keypair_encoding) -> (crypto_errno, keypair)`
+#### <a href="#keypair_import" name="keypair_import"></a> `keypair_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: keypair_encoding) -> Result<keypair, crypto_errno>`
 Import a key pair.
 
 This function creates a [`keypair`](#keypair) object from existing material.
@@ -790,14 +878,21 @@ let kp_handle = ctx.keypair_import(AlgorithmType::Signatures, "RSA_PKCS1_2048_SH
 - <a href="#keypair_import.encoding" name="keypair_import.encoding"></a> `encoding`: [`keypair_encoding`](#keypair_encoding)
 
 ##### Results
-- <a href="#keypair_import.error" name="keypair_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_import.error" name="keypair_import.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_import.handle" name="keypair_import.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_import.error.ok" name="keypair_import.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_import.error.err" name="keypair_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_generate_managed" name="keypair_generate_managed"></a> `keypair_generate_managed(secrets_manager: secrets_manager, algorithm_type: algorithm_type, algorithm: string, options: opt_options) -> (crypto_errno, keypair)`
+#### <a href="#keypair_generate_managed" name="keypair_generate_managed"></a> `keypair_generate_managed(secrets_manager: secrets_manager, algorithm_type: algorithm_type, algorithm: string, options: opt_options) -> Result<keypair, crypto_errno>`
 __(optional)__
 Generate a new managed key pair.
 
@@ -822,14 +917,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#keypair_generate_managed.options" name="keypair_generate_managed.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#keypair_generate_managed.error" name="keypair_generate_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_generate_managed.error" name="keypair_generate_managed.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_generate_managed.handle" name="keypair_generate_managed.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_generate_managed.error.ok" name="keypair_generate_managed.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_generate_managed.error.err" name="keypair_generate_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_store_managed" name="keypair_store_managed"></a> `keypair_store_managed(secrets_manager: secrets_manager, kp: keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> crypto_errno`
+#### <a href="#keypair_store_managed" name="keypair_store_managed"></a> `keypair_store_managed(secrets_manager: secrets_manager, kp: keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> Result<(), crypto_errno>`
 __(optional)__
 Store a key pair into the secrets manager.
 
@@ -848,12 +950,21 @@ The function returns `overflow` if the supplied buffer is too small.
 - <a href="#keypair_store_managed.kp_id_max_len" name="keypair_store_managed.kp_id_max_len"></a> `kp_id_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#keypair_store_managed.error" name="keypair_store_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_store_managed.error" name="keypair_store_managed.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_store_managed.error.ok" name="keypair_store_managed.error.ok"></a> `ok`
+
+- <a href="#keypair_store_managed.error.err" name="keypair_store_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_replace_managed" name="keypair_replace_managed"></a> `keypair_replace_managed(secrets_manager: secrets_manager, kp_old: keypair, kp_new: keypair) -> (crypto_errno, version)`
+#### <a href="#keypair_replace_managed" name="keypair_replace_managed"></a> `keypair_replace_managed(secrets_manager: secrets_manager, kp_old: keypair, kp_new: keypair) -> Result<version, crypto_errno>`
 __(optional)__
 Replace a managed key pair.
 
@@ -884,14 +995,21 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#keypair_replace_managed.kp_new" name="keypair_replace_managed.kp_new"></a> `kp_new`: [`keypair`](#keypair)
 
 ##### Results
-- <a href="#keypair_replace_managed.error" name="keypair_replace_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_replace_managed.error" name="keypair_replace_managed.error"></a> `error`: `Result<version, crypto_errno>`
 
-- <a href="#keypair_replace_managed.version" name="keypair_replace_managed.version"></a> `version`: [`version`](#version)
+###### Variant Layout
+- size: 16
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_replace_managed.error.ok" name="keypair_replace_managed.error.ok"></a> `ok`: [`version`](#version)
+
+- <a href="#keypair_replace_managed.error.err" name="keypair_replace_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_id" name="keypair_id"></a> `keypair_id(kp: keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> (crypto_errno, size, version)`
+#### <a href="#keypair_id" name="keypair_id"></a> `keypair_id(kp: keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> Result<(size, version), crypto_errno>`
 __(optional)__
 Return the key pair identifier and version of a managed key pair.
 
@@ -907,16 +1025,30 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#keypair_id.kp_id_max_len" name="keypair_id.kp_id_max_len"></a> `kp_id_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#keypair_id.error" name="keypair_id.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_id.error" name="keypair_id.error"></a> `error`: `Result<(size, version), crypto_errno>`
 
-- <a href="#keypair_id.kp_id_len" name="keypair_id.kp_id_len"></a> `kp_id_len`: [`size`](#size)
+###### Variant Layout
+- size: 24
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_id.error.ok" name="keypair_id.error.ok"></a> `ok`: `(size, version)`
 
-- <a href="#keypair_id.version" name="keypair_id.version"></a> `version`: [`version`](#version)
+####### Record members
+- <a href="#keypair_id.error.ok.0" name="keypair_id.error.ok.0"></a> `0`: [`size`](#size)
+
+Offset: 0
+
+- <a href="#keypair_id.error.ok.1" name="keypair_id.error.ok.1"></a> `1`: [`version`](#version)
+
+Offset: 8
+
+- <a href="#keypair_id.error.err" name="keypair_id.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_from_id" name="keypair_from_id"></a> `keypair_from_id(secrets_manager: secrets_manager, kp_id: ConstPointer<u8>, kp_id_len: size, kp_version: version) -> (crypto_errno, keypair)`
+#### <a href="#keypair_from_id" name="keypair_from_id"></a> `keypair_from_id(secrets_manager: secrets_manager, kp_id: ConstPointer<u8>, kp_id_len: size, kp_version: version) -> Result<keypair, crypto_errno>`
 __(optional)__
 Return a managed key pair from a key identifier.
 
@@ -936,14 +1068,21 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#keypair_from_id.kp_version" name="keypair_from_id.kp_version"></a> `kp_version`: [`version`](#version)
 
 ##### Results
-- <a href="#keypair_from_id.error" name="keypair_from_id.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_from_id.error" name="keypair_from_id.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_from_id.handle" name="keypair_from_id.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_from_id.error.ok" name="keypair_from_id.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_from_id.error.err" name="keypair_from_id.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_from_pk_and_sk" name="keypair_from_pk_and_sk"></a> `keypair_from_pk_and_sk(publickey: publickey, secretkey: secretkey) -> (crypto_errno, keypair)`
+#### <a href="#keypair_from_pk_and_sk" name="keypair_from_pk_and_sk"></a> `keypair_from_pk_and_sk(publickey: publickey, secretkey: secretkey) -> Result<keypair, crypto_errno>`
 Create a key pair from a public key and a secret key.
 
 ##### Params
@@ -952,14 +1091,21 @@ Create a key pair from a public key and a secret key.
 - <a href="#keypair_from_pk_and_sk.secretkey" name="keypair_from_pk_and_sk.secretkey"></a> `secretkey`: [`secretkey`](#secretkey)
 
 ##### Results
-- <a href="#keypair_from_pk_and_sk.error" name="keypair_from_pk_and_sk.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_from_pk_and_sk.error" name="keypair_from_pk_and_sk.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_from_pk_and_sk.handle" name="keypair_from_pk_and_sk.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_from_pk_and_sk.error.ok" name="keypair_from_pk_and_sk.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_from_pk_and_sk.error.err" name="keypair_from_pk_and_sk.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_export" name="keypair_export"></a> `keypair_export(kp: keypair, encoding: keypair_encoding) -> (crypto_errno, array_output)`
+#### <a href="#keypair_export" name="keypair_export"></a> `keypair_export(kp: keypair, encoding: keypair_encoding) -> Result<array_output, crypto_errno>`
 Export a key pair as the given encoding format.
 
 May return `prohibited_operation` if this operation is denied or `unsupported_encoding` if the encoding is not supported.
@@ -970,42 +1116,63 @@ May return `prohibited_operation` if this operation is denied or `unsupported_en
 - <a href="#keypair_export.encoding" name="keypair_export.encoding"></a> `encoding`: [`keypair_encoding`](#keypair_encoding)
 
 ##### Results
-- <a href="#keypair_export.error" name="keypair_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_export.error" name="keypair_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#keypair_export.encoded" name="keypair_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_export.error.ok" name="keypair_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#keypair_export.error.err" name="keypair_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_publickey" name="keypair_publickey"></a> `keypair_publickey(kp: keypair) -> (crypto_errno, publickey)`
+#### <a href="#keypair_publickey" name="keypair_publickey"></a> `keypair_publickey(kp: keypair) -> Result<publickey, crypto_errno>`
 Get the public key of a key pair.
 
 ##### Params
 - <a href="#keypair_publickey.kp" name="keypair_publickey.kp"></a> `kp`: [`keypair`](#keypair)
 
 ##### Results
-- <a href="#keypair_publickey.error" name="keypair_publickey.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_publickey.error" name="keypair_publickey.error"></a> `error`: `Result<publickey, crypto_errno>`
 
-- <a href="#keypair_publickey.pk" name="keypair_publickey.pk"></a> `pk`: [`publickey`](#publickey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_publickey.error.ok" name="keypair_publickey.error.ok"></a> `ok`: [`publickey`](#publickey)
+
+- <a href="#keypair_publickey.error.err" name="keypair_publickey.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_secretkey" name="keypair_secretkey"></a> `keypair_secretkey(kp: keypair) -> (crypto_errno, secretkey)`
+#### <a href="#keypair_secretkey" name="keypair_secretkey"></a> `keypair_secretkey(kp: keypair) -> Result<secretkey, crypto_errno>`
 Get the secret key of a key pair.
 
 ##### Params
 - <a href="#keypair_secretkey.kp" name="keypair_secretkey.kp"></a> `kp`: [`keypair`](#keypair)
 
 ##### Results
-- <a href="#keypair_secretkey.error" name="keypair_secretkey.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_secretkey.error" name="keypair_secretkey.error"></a> `error`: `Result<secretkey, crypto_errno>`
 
-- <a href="#keypair_secretkey.sk" name="keypair_secretkey.sk"></a> `sk`: [`secretkey`](#secretkey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_secretkey.error.ok" name="keypair_secretkey.error.ok"></a> `ok`: [`secretkey`](#secretkey)
+
+- <a href="#keypair_secretkey.error.err" name="keypair_secretkey.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_close" name="keypair_close"></a> `keypair_close(kp: keypair) -> crypto_errno`
+#### <a href="#keypair_close" name="keypair_close"></a> `keypair_close(kp: keypair) -> Result<(), crypto_errno>`
 Destroy a key pair.
 
 The host will automatically wipe traces of the secret key from memory.
@@ -1016,12 +1183,21 @@ If this is a managed key, the key will not be removed from persistent storage, a
 - <a href="#keypair_close.kp" name="keypair_close.kp"></a> `kp`: [`keypair`](#keypair)
 
 ##### Results
-- <a href="#keypair_close.error" name="keypair_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_close.error" name="keypair_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_close.error.ok" name="keypair_close.error.ok"></a> `ok`
+
+- <a href="#keypair_close.error.err" name="keypair_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_import" name="publickey_import"></a> `publickey_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: publickey_encoding) -> (crypto_errno, publickey)`
+#### <a href="#publickey_import" name="publickey_import"></a> `publickey_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: publickey_encoding) -> Result<publickey, crypto_errno>`
 Import a public key.
 
 The function may return `unsupported_encoding` if importing from the given format is not implemented or incompatible with the key type.
@@ -1048,14 +1224,21 @@ let pk_handle = ctx.publickey_import(AlgorithmType::Signatures, encoded, PublicK
 - <a href="#publickey_import.encoding" name="publickey_import.encoding"></a> `encoding`: [`publickey_encoding`](#publickey_encoding)
 
 ##### Results
-- <a href="#publickey_import.error" name="publickey_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_import.error" name="publickey_import.error"></a> `error`: `Result<publickey, crypto_errno>`
 
-- <a href="#publickey_import.pk" name="publickey_import.pk"></a> `pk`: [`publickey`](#publickey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_import.error.ok" name="publickey_import.error.ok"></a> `ok`: [`publickey`](#publickey)
+
+- <a href="#publickey_import.error.err" name="publickey_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_export" name="publickey_export"></a> `publickey_export(pk: publickey, encoding: publickey_encoding) -> (crypto_errno, array_output)`
+#### <a href="#publickey_export" name="publickey_export"></a> `publickey_export(pk: publickey, encoding: publickey_encoding) -> Result<array_output, crypto_errno>`
 Export a public key as the given encoding format.
 
 May return `unsupported_encoding` if the encoding is not supported.
@@ -1066,14 +1249,21 @@ May return `unsupported_encoding` if the encoding is not supported.
 - <a href="#publickey_export.encoding" name="publickey_export.encoding"></a> `encoding`: [`publickey_encoding`](#publickey_encoding)
 
 ##### Results
-- <a href="#publickey_export.error" name="publickey_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_export.error" name="publickey_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#publickey_export.encoded" name="publickey_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_export.error.ok" name="publickey_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#publickey_export.error.err" name="publickey_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_verify" name="publickey_verify"></a> `publickey_verify(pk: publickey) -> crypto_errno`
+#### <a href="#publickey_verify" name="publickey_verify"></a> `publickey_verify(pk: publickey) -> Result<(), crypto_errno>`
 Check that a public key is valid and in canonical form.
 
 This function may perform stricter checks than those made during importation at the expense of additional CPU cycles.
@@ -1084,26 +1274,42 @@ The function returns `invalid_key` if the public key didn't pass the checks.
 - <a href="#publickey_verify.pk" name="publickey_verify.pk"></a> `pk`: [`publickey`](#publickey)
 
 ##### Results
-- <a href="#publickey_verify.error" name="publickey_verify.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_verify.error" name="publickey_verify.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_verify.error.ok" name="publickey_verify.error.ok"></a> `ok`
+
+- <a href="#publickey_verify.error.err" name="publickey_verify.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_from_secretkey" name="publickey_from_secretkey"></a> `publickey_from_secretkey(sk: secretkey) -> (crypto_errno, publickey)`
+#### <a href="#publickey_from_secretkey" name="publickey_from_secretkey"></a> `publickey_from_secretkey(sk: secretkey) -> Result<publickey, crypto_errno>`
 Compute the public key for a secret key.
 
 ##### Params
 - <a href="#publickey_from_secretkey.sk" name="publickey_from_secretkey.sk"></a> `sk`: [`secretkey`](#secretkey)
 
 ##### Results
-- <a href="#publickey_from_secretkey.error" name="publickey_from_secretkey.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_from_secretkey.error" name="publickey_from_secretkey.error"></a> `error`: `Result<publickey, crypto_errno>`
 
-- <a href="#publickey_from_secretkey.pk" name="publickey_from_secretkey.pk"></a> `pk`: [`publickey`](#publickey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_from_secretkey.error.ok" name="publickey_from_secretkey.error.ok"></a> `ok`: [`publickey`](#publickey)
+
+- <a href="#publickey_from_secretkey.error.err" name="publickey_from_secretkey.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_close" name="publickey_close"></a> `publickey_close(pk: publickey) -> crypto_errno`
+#### <a href="#publickey_close" name="publickey_close"></a> `publickey_close(pk: publickey) -> Result<(), crypto_errno>`
 Destroy a public key.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1112,12 +1318,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#publickey_close.pk" name="publickey_close.pk"></a> `pk`: [`publickey`](#publickey)
 
 ##### Results
-- <a href="#publickey_close.error" name="publickey_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_close.error" name="publickey_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_close.error.ok" name="publickey_close.error.ok"></a> `ok`
+
+- <a href="#publickey_close.error.err" name="publickey_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secretkey_import" name="secretkey_import"></a> `secretkey_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: secretkey_encoding) -> (crypto_errno, secretkey)`
+#### <a href="#secretkey_import" name="secretkey_import"></a> `secretkey_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: secretkey_encoding) -> Result<secretkey, crypto_errno>`
 Import a secret key.
 
 The function may return `unsupported_encoding` if importing from the given format is not implemented or incompatible with the key type.
@@ -1144,14 +1359,21 @@ let pk_handle = ctx.secretkey_import(AlgorithmType::KX, encoded, SecretKeyEncodi
 - <a href="#secretkey_import.encoding" name="secretkey_import.encoding"></a> `encoding`: [`secretkey_encoding`](#secretkey_encoding)
 
 ##### Results
-- <a href="#secretkey_import.error" name="secretkey_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secretkey_import.error" name="secretkey_import.error"></a> `error`: `Result<secretkey, crypto_errno>`
 
-- <a href="#secretkey_import.sk" name="secretkey_import.sk"></a> `sk`: [`secretkey`](#secretkey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secretkey_import.error.ok" name="secretkey_import.error.ok"></a> `ok`: [`secretkey`](#secretkey)
+
+- <a href="#secretkey_import.error.err" name="secretkey_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secretkey_export" name="secretkey_export"></a> `secretkey_export(sk: secretkey, encoding: secretkey_encoding) -> (crypto_errno, array_output)`
+#### <a href="#secretkey_export" name="secretkey_export"></a> `secretkey_export(sk: secretkey, encoding: secretkey_encoding) -> Result<array_output, crypto_errno>`
 Export a secret key as the given encoding format.
 
 May return `unsupported_encoding` if the encoding is not supported.
@@ -1162,14 +1384,21 @@ May return `unsupported_encoding` if the encoding is not supported.
 - <a href="#secretkey_export.encoding" name="secretkey_export.encoding"></a> `encoding`: [`secretkey_encoding`](#secretkey_encoding)
 
 ##### Results
-- <a href="#secretkey_export.error" name="secretkey_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secretkey_export.error" name="secretkey_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#secretkey_export.encoded" name="secretkey_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secretkey_export.error.ok" name="secretkey_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#secretkey_export.error.err" name="secretkey_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secretkey_close" name="secretkey_close"></a> `secretkey_close(sk: secretkey) -> crypto_errno`
+#### <a href="#secretkey_close" name="secretkey_close"></a> `secretkey_close(sk: secretkey) -> Result<(), crypto_errno>`
 Destroy a secret key.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1178,7 +1407,16 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#secretkey_close.sk" name="secretkey_close.sk"></a> `sk`: [`secretkey`](#secretkey)
 
 ##### Results
-- <a href="#secretkey_close.error" name="secretkey_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secretkey_close.error" name="secretkey_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secretkey_close.error.ok" name="secretkey_close.error.ok"></a> `ok`
+
+- <a href="#secretkey_close.error.err" name="secretkey_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 ## <a href="#wasi_ephemeral_crypto_signatures" name="wasi_ephemeral_crypto_signatures"></a> wasi_ephemeral_crypto_signatures
 ### Imports
@@ -1187,7 +1425,7 @@ Objects are reference counted. It is safe to close an object immediately after t
 
 ---
 
-#### <a href="#signature_export" name="signature_export"></a> `signature_export(signature: signature, encoding: signature_encoding) -> (crypto_errno, array_output)`
+#### <a href="#signature_export" name="signature_export"></a> `signature_export(signature: signature, encoding: signature_encoding) -> Result<array_output, crypto_errno>`
 Export a signature.
 
 This function exports a signature object using the specified encoding.
@@ -1200,14 +1438,21 @@ May return `unsupported_encoding` if the signature cannot be encoded into the gi
 - <a href="#signature_export.encoding" name="signature_export.encoding"></a> `encoding`: [`signature_encoding`](#signature_encoding)
 
 ##### Results
-- <a href="#signature_export.error" name="signature_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_export.error" name="signature_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#signature_export.encoded" name="signature_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_export.error.ok" name="signature_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#signature_export.error.err" name="signature_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_import" name="signature_import"></a> `signature_import(algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: signature_encoding) -> (crypto_errno, signature)`
+#### <a href="#signature_import" name="signature_import"></a> `signature_import(algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: signature_encoding) -> Result<signature, crypto_errno>`
 Create a signature object.
 
 This object can be used along with a public key to verify an existing signature.
@@ -1232,14 +1477,21 @@ let signature_handle = ctx.signature_import("ECDSA_P256_SHA256", SignatureEncodi
 - <a href="#signature_import.encoding" name="signature_import.encoding"></a> `encoding`: [`signature_encoding`](#signature_encoding)
 
 ##### Results
-- <a href="#signature_import.error" name="signature_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_import.error" name="signature_import.error"></a> `error`: `Result<signature, crypto_errno>`
 
-- <a href="#signature_import.signature" name="signature_import.signature"></a> `signature`: [`signature`](#signature)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_import.error.ok" name="signature_import.error.ok"></a> `ok`: [`signature`](#signature)
+
+- <a href="#signature_import.error.err" name="signature_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_state_open" name="signature_state_open"></a> `signature_state_open(kp: signature_keypair) -> (crypto_errno, signature_state)`
+#### <a href="#signature_state_open" name="signature_state_open"></a> `signature_state_open(kp: signature_keypair) -> Result<signature_state, crypto_errno>`
 Create a new state to collect data to compute a signature on.
 
 This function allows data to be signed to be supplied in a streaming fashion.
@@ -1261,14 +1513,21 @@ let raw_sig = ctx.signature_export(sig_handle, SignatureEncoding::Raw)?;
 - <a href="#signature_state_open.kp" name="signature_state_open.kp"></a> `kp`: [`signature_keypair`](#signature_keypair)
 
 ##### Results
-- <a href="#signature_state_open.error" name="signature_state_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_state_open.error" name="signature_state_open.error"></a> `error`: `Result<signature_state, crypto_errno>`
 
-- <a href="#signature_state_open.state" name="signature_state_open.state"></a> `state`: [`signature_state`](#signature_state)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_state_open.error.ok" name="signature_state_open.error.ok"></a> `ok`: [`signature_state`](#signature_state)
+
+- <a href="#signature_state_open.error.err" name="signature_state_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_state_update" name="signature_state_update"></a> `signature_state_update(state: signature_state, input: ConstPointer<u8>, input_len: size) -> crypto_errno`
+#### <a href="#signature_state_update" name="signature_state_update"></a> `signature_state_update(state: signature_state, input: ConstPointer<u8>, input_len: size) -> Result<(), crypto_errno>`
 Absorb data into the signature state.
 
 This function may return `unsupported_feature` is the selected algorithm doesn't support incremental updates.
@@ -1281,12 +1540,21 @@ This function may return `unsupported_feature` is the selected algorithm doesn't
 - <a href="#signature_state_update.input_len" name="signature_state_update.input_len"></a> `input_len`: [`size`](#size)
 
 ##### Results
-- <a href="#signature_state_update.error" name="signature_state_update.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_state_update.error" name="signature_state_update.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_state_update.error.ok" name="signature_state_update.error.ok"></a> `ok`
+
+- <a href="#signature_state_update.error.err" name="signature_state_update.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_state_sign" name="signature_state_sign"></a> `signature_state_sign(state: signature_state) -> (crypto_errno, array_output)`
+#### <a href="#signature_state_sign" name="signature_state_sign"></a> `signature_state_sign(state: signature_state) -> Result<array_output, crypto_errno>`
 Compute a signature for all the data collected up to that point.
 
 The function can be called multiple times for incremental signing.
@@ -1295,14 +1563,21 @@ The function can be called multiple times for incremental signing.
 - <a href="#signature_state_sign.state" name="signature_state_sign.state"></a> `state`: [`signature_state`](#signature_state)
 
 ##### Results
-- <a href="#signature_state_sign.error" name="signature_state_sign.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_state_sign.error" name="signature_state_sign.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#signature_state_sign.signature" name="signature_state_sign.signature"></a> `signature`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_state_sign.error.ok" name="signature_state_sign.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#signature_state_sign.error.err" name="signature_state_sign.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_state_close" name="signature_state_close"></a> `signature_state_close(state: signature_state) -> crypto_errno`
+#### <a href="#signature_state_close" name="signature_state_close"></a> `signature_state_close(state: signature_state) -> Result<(), crypto_errno>`
 Destroy a signature state.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1313,12 +1588,21 @@ Note that closing a signature state doesn't close or invalidate the key pair obj
 - <a href="#signature_state_close.state" name="signature_state_close.state"></a> `state`: [`signature_state`](#signature_state)
 
 ##### Results
-- <a href="#signature_state_close.error" name="signature_state_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_state_close.error" name="signature_state_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_state_close.error.ok" name="signature_state_close.error.ok"></a> `ok`
+
+- <a href="#signature_state_close.error.err" name="signature_state_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_verification_state_open" name="signature_verification_state_open"></a> `signature_verification_state_open(kp: signature_publickey) -> (crypto_errno, signature_verification_state)`
+#### <a href="#signature_verification_state_open" name="signature_verification_state_open"></a> `signature_verification_state_open(kp: signature_publickey) -> Result<signature_verification_state, crypto_errno>`
 Create a new state to collect data to verify a signature on.
 
 This is the verification counterpart of [`signature_state`](#signature_state).
@@ -1339,14 +1623,21 @@ ctx.signature_verification_state_verify(signature_handle)?;
 - <a href="#signature_verification_state_open.kp" name="signature_verification_state_open.kp"></a> `kp`: [`signature_publickey`](#signature_publickey)
 
 ##### Results
-- <a href="#signature_verification_state_open.error" name="signature_verification_state_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_verification_state_open.error" name="signature_verification_state_open.error"></a> `error`: `Result<signature_verification_state, crypto_errno>`
 
-- <a href="#signature_verification_state_open.state" name="signature_verification_state_open.state"></a> `state`: [`signature_verification_state`](#signature_verification_state)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_verification_state_open.error.ok" name="signature_verification_state_open.error.ok"></a> `ok`: [`signature_verification_state`](#signature_verification_state)
+
+- <a href="#signature_verification_state_open.error.err" name="signature_verification_state_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_verification_state_update" name="signature_verification_state_update"></a> `signature_verification_state_update(state: signature_verification_state, input: ConstPointer<u8>, input_len: size) -> crypto_errno`
+#### <a href="#signature_verification_state_update" name="signature_verification_state_update"></a> `signature_verification_state_update(state: signature_verification_state, input: ConstPointer<u8>, input_len: size) -> Result<(), crypto_errno>`
 Absorb data into the signature verification state.
 
 This function may return `unsupported_feature` is the selected algorithm doesn't support incremental updates.
@@ -1359,12 +1650,21 @@ This function may return `unsupported_feature` is the selected algorithm doesn't
 - <a href="#signature_verification_state_update.input_len" name="signature_verification_state_update.input_len"></a> `input_len`: [`size`](#size)
 
 ##### Results
-- <a href="#signature_verification_state_update.error" name="signature_verification_state_update.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_verification_state_update.error" name="signature_verification_state_update.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_verification_state_update.error.ok" name="signature_verification_state_update.error.ok"></a> `ok`
+
+- <a href="#signature_verification_state_update.error.err" name="signature_verification_state_update.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_verification_state_verify" name="signature_verification_state_verify"></a> `signature_verification_state_verify(state: signature_verification_state, signature: signature) -> crypto_errno`
+#### <a href="#signature_verification_state_verify" name="signature_verification_state_verify"></a> `signature_verification_state_verify(state: signature_verification_state, signature: signature) -> Result<(), crypto_errno>`
 Check that the given signature is verifies for the data collected up to that point point.
 
 The state is not closed and can absorb more data to allow for incremental verification.
@@ -1377,12 +1677,21 @@ The function returns `invalid_signature` if the signature doesn't appear to be v
 - <a href="#signature_verification_state_verify.signature" name="signature_verification_state_verify.signature"></a> `signature`: [`signature`](#signature)
 
 ##### Results
-- <a href="#signature_verification_state_verify.error" name="signature_verification_state_verify.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_verification_state_verify.error" name="signature_verification_state_verify.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_verification_state_verify.error.ok" name="signature_verification_state_verify.error.ok"></a> `ok`
+
+- <a href="#signature_verification_state_verify.error.err" name="signature_verification_state_verify.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_verification_state_close" name="signature_verification_state_close"></a> `signature_verification_state_close(state: signature_verification_state) -> crypto_errno`
+#### <a href="#signature_verification_state_close" name="signature_verification_state_close"></a> `signature_verification_state_close(state: signature_verification_state) -> Result<(), crypto_errno>`
 Destroy a signature verification state.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1393,12 +1702,21 @@ Note that closing a signature state doesn't close or invalidate the public key o
 - <a href="#signature_verification_state_close.state" name="signature_verification_state_close.state"></a> `state`: [`signature_verification_state`](#signature_verification_state)
 
 ##### Results
-- <a href="#signature_verification_state_close.error" name="signature_verification_state_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_verification_state_close.error" name="signature_verification_state_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_verification_state_close.error.ok" name="signature_verification_state_close.error.ok"></a> `ok`
+
+- <a href="#signature_verification_state_close.error.err" name="signature_verification_state_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_close" name="signature_close"></a> `signature_close(signature: signature) -> crypto_errno`
+#### <a href="#signature_close" name="signature_close"></a> `signature_close(signature: signature) -> Result<(), crypto_errno>`
 Destroy a signature.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1407,5 +1725,15 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#signature_close.signature" name="signature_close.signature"></a> `signature`: [`signature`](#signature)
 
 ##### Results
-- <a href="#signature_close.error" name="signature_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_close.error" name="signature_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_close.error.ok" name="signature_close.error.ok"></a> `ok`
+
+- <a href="#signature_close.error.err" name="signature_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
+
 

--- a/witx/proposal_signatures.witx
+++ b/witx/proposal_signatures.witx
@@ -28,8 +28,7 @@
   (@interface func (export "signature_export")
     (param $signature $signature)
     (param $encoding $signature_encoding)
-    (result $error $crypto_errno)
-    (result $encoded $array_output)
+    (result $error (expected $array_output (error $crypto_errno)))
   )
 
   ;;; Create a signature object.
@@ -50,8 +49,7 @@
     (param $encoded (@witx const_pointer u8))
     (param $encoded_len $size)
     (param $encoding $signature_encoding)
-    (result $error $crypto_errno)
-    (result $signature $signature)
+    (result $error (expected $signature (error $crypto_errno)))
   )
 
   ;;; Create a new state to collect data to compute a signature on.
@@ -72,8 +70,7 @@
   ;;; ```
   (@interface func (export "signature_state_open")
     (param $kp $signature_keypair)
-    (result $error $crypto_errno)
-    (result $state $signature_state)
+    (result $error (expected $signature_state (error $crypto_errno)))
   )
 
   ;;; Absorb data into the signature state.
@@ -83,7 +80,7 @@
     (param $state $signature_state)
     (param $input (@witx const_pointer u8))
     (param $input_len $size)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Compute a signature for all the data collected up to that point.
@@ -91,8 +88,7 @@
   ;;; The function can be called multiple times for incremental signing.
   (@interface func (export "signature_state_sign")
     (param $state $signature_state)
-    (result $error $crypto_errno)
-    (result $signature $array_output)
+    (result $error (expected $array_output (error $crypto_errno)))
   )
 
   ;;; Destroy a signature state.
@@ -102,7 +98,7 @@
   ;;; Note that closing a signature state doesn't close or invalidate the key pair object, that be reused for further signatures.
   (@interface func (export "signature_state_close")
     (param $state $signature_state)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Create a new state to collect data to verify a signature on.
@@ -122,8 +118,7 @@
   ;;; ```
   (@interface func (export "signature_verification_state_open")
     (param $kp $signature_publickey)
-    (result $error $crypto_errno)
-    (result $state $signature_verification_state)
+    (result $error (expected $signature_verification_state (error $crypto_errno)))
   )
 
   ;;; Absorb data into the signature verification state.
@@ -133,7 +128,7 @@
     (param $state $signature_verification_state)
     (param $input (@witx const_pointer u8))
     (param $input_len $size)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Check that the given signature is verifies for the data collected up to that point point.
@@ -144,7 +139,7 @@
   (@interface func (export "signature_verification_state_verify")
     (param $state $signature_verification_state)
     (param $signature $signature)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Destroy a signature verification state.
@@ -154,7 +149,7 @@
   ;;; Note that closing a signature state doesn't close or invalidate the public key object, that be reused for further verifications.
   (@interface func (export "signature_verification_state_close")
     (param $state $signature_verification_state)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Destroy a signature.
@@ -162,6 +157,6 @@
   ;;; Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
   (@interface func (export "signature_close")
     (param $signature $signature)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 )

--- a/witx/proposal_symmetric.md
+++ b/witx/proposal_symmetric.md
@@ -1,12 +1,12 @@
 # Types
-## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: Enum(`u16`)
+## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: `Variant`
 Error codes.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#crypto_errno.success" name="crypto_errno.success"></a> `success`
 Operation succeeded.
 
@@ -151,14 +151,14 @@ This error is returned when trying to build a key pair from a public key and a s
 - <a href="#crypto_errno.expired" name="crypto_errno.expired"></a> `expired`
 A managed key or secret expired and cannot be used any more.
 
-## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: Enum(`u16`)
+## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: `Variant`
 Encoding to use for importing or exporting a key pair.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#keypair_encoding.raw" name="keypair_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -171,14 +171,14 @@ PEM encoding.
 - <a href="#keypair_encoding.local" name="keypair_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: Enum(`u16`)
+## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: `Variant`
 Encoding to use for importing or exporting a public key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#publickey_encoding.raw" name="publickey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -197,14 +197,14 @@ Compressed SEC encoding.
 - <a href="#publickey_encoding.local" name="publickey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: Enum(`u16`)
+## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: `Variant`
 Encoding to use for importing or exporting a secret key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#secretkey_encoding.raw" name="secretkey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -223,52 +223,49 @@ Compressed SEC encoding.
 - <a href="#secretkey_encoding.local" name="secretkey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: Enum(`u16`)
+## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: `Variant`
 Encoding to use for importing or exporting a signature.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#signature_encoding.raw" name="signature_encoding.raw"></a> `raw`
 Raw bytes.
 
 - <a href="#signature_encoding.der" name="signature_encoding.der"></a> `der`
 DER encoding.
 
-## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: Enum(`u16`)
+## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: `Variant`
 An algorithm category.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#algorithm_type.signatures" name="algorithm_type.signatures"></a> `signatures`
 
 - <a href="#algorithm_type.symmetric" name="algorithm_type.symmetric"></a> `symmetric`
 
 - <a href="#algorithm_type.key_exchange" name="algorithm_type.key_exchange"></a> `key_exchange`
 
-## <a href="#version" name="version"></a> `version`: Int(`u64`)
+## <a href="#version" name="version"></a> `version`: `u64`
 Version of a managed key.
 
-A version can be an arbitrary `u64` integer, with the expection of some reserved values.
+A version can be an arbitrary [`u64`](#u64) integer, with the expection of some reserved values.
 
 Size: 8
 
 Alignment: 8
 
-### Consts
+### Constants
 - <a href="#version.unspecified" name="version.unspecified"></a> `unspecified`
-Key doesn't support versioning.
 
 - <a href="#version.latest" name="version.latest"></a> `latest`
-Use the latest version of a key.
 
 - <a href="#version.all" name="version.all"></a> `all`
-Perform an operation over all versions of a key.
 
 ## <a href="#size" name="size"></a> `size`: `usize`
 Size of a value.
@@ -284,7 +281,7 @@ Size: 8
 
 Alignment: 8
 
-## <a href="#array_output" name="array_output"></a> `array_output`
+## <a href="#array_output" name="array_output"></a> `array_output`: `Handle`
 Handle for functions returning output whose size may be large or not known in advance.
 
 An [`array_output`](#array_output) object contains a host-allocated byte array.
@@ -299,7 +296,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#options" name="options"></a> `options`
+## <a href="#options" name="options"></a> `options`: `Handle`
 A set of options.
 
 This type is used to set non-default parameters.
@@ -311,7 +308,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`
+## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`: `Handle`
 A handle to the optional secrets management facilities offered by a host.
 
 This is used to generate, retrieve and invalidate managed keys.
@@ -321,7 +318,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#keypair" name="keypair"></a> `keypair`
+## <a href="#keypair" name="keypair"></a> `keypair`: `Handle`
 A key pair.
 
 Size: 4
@@ -329,7 +326,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_state" name="signature_state"></a> `signature_state`
+## <a href="#signature_state" name="signature_state"></a> `signature_state`: `Handle`
 A state to absorb data to be signed.
 
 After a signature has been computed or verified, the state remains valid for further operations.
@@ -341,7 +338,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature" name="signature"></a> `signature`
+## <a href="#signature" name="signature"></a> `signature`: `Handle`
 A signature.
 
 Size: 4
@@ -349,7 +346,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#publickey" name="publickey"></a> `publickey`
+## <a href="#publickey" name="publickey"></a> `publickey`: `Handle`
 A public key, for key exchange and signature verification.
 
 Size: 4
@@ -357,7 +354,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secretkey" name="secretkey"></a> `secretkey`
+## <a href="#secretkey" name="secretkey"></a> `secretkey`: `Handle`
 A secret key, for key exchange mechanisms.
 
 Size: 4
@@ -365,7 +362,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`
+## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`: `Handle`
 A state to absorb signed data to be verified.
 
 Size: 4
@@ -373,7 +370,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`
+## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`: `Handle`
 A state to perform symmetric operations.
 
 The state is not reset nor invalidated after an option has been performed.
@@ -384,7 +381,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`
+## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`: `Handle`
 A symmetric key.
 
 The key can be imported from raw bytes, or can be a reference to a managed key.
@@ -396,7 +393,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`
+## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`: `Handle`
 An authentication tag.
 
 This is an object returned by functions computing authentication tags.
@@ -412,19 +409,19 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: Enum(`u8`)
+## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: `Variant`
 Options index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_options_u.some" name="opt_options_u.some"></a> `some`
 
 - <a href="#opt_options_u.none" name="opt_options_u.none"></a> `none`
 
-## <a href="#opt_options" name="opt_options"></a> `opt_options`: Union
+## <a href="#opt_options" name="opt_options"></a> `opt_options`: `Variant`
 An optional options set.
 
 This union simulates an `Option<Options>` type to make the [`options`](#options) parameter of some functions optional.
@@ -433,30 +430,28 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_options.some" name="opt_options.some"></a> `some`: [`options`](#options)
 
 - <a href="#opt_options.none" name="opt_options.none"></a> `none`
 
-## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: Enum(`u8`)
+## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: `Variant`
 Symmetric key index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_symmetric_key_u.some" name="opt_symmetric_key_u.some"></a> `some`
 
 - <a href="#opt_symmetric_key_u.none" name="opt_symmetric_key_u.none"></a> `none`
 
-## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: Union
+## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: `Variant`
 An optional symmetric key.
 
 This union simulates an `Option<SymmetricKey>` type to make the [`symmetric_key`](#symmetric_key) parameter of some functions optional.
@@ -465,16 +460,20 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_symmetric_key.some" name="opt_symmetric_key.some"></a> `some`: [`symmetric_key`](#symmetric_key)
 
 - <a href="#opt_symmetric_key.none" name="opt_symmetric_key.none"></a> `none`
+
+## <a href="#u64" name="u64"></a> `u64`: `u64`
+
+Size: 8
+
+Alignment: 8
 
 # Modules
 ## <a href="#wasi_ephemeral_crypto_common" name="wasi_ephemeral_crypto_common"></a> wasi_ephemeral_crypto_common
@@ -484,7 +483,7 @@ Alignment: 4
 
 ---
 
-#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> (crypto_errno, options)`
+#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> Result<options, crypto_errno>`
 Create a new object to set non-default options.
 
 Example usage:
@@ -501,14 +500,21 @@ options_close(options_handle)?;
 - <a href="#options_open.algorithm_type" name="options_open.algorithm_type"></a> `algorithm_type`: [`algorithm_type`](#algorithm_type)
 
 ##### Results
-- <a href="#options_open.error" name="options_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_open.error" name="options_open.error"></a> `error`: `Result<options, crypto_errno>`
 
-- <a href="#options_open.handle" name="options_open.handle"></a> `handle`: [`options`](#options)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_open.error.ok" name="options_open.error.ok"></a> `ok`: [`options`](#options)
+
+- <a href="#options_open.error.err" name="options_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> crypto_errno`
+#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> Result<(), crypto_errno>`
 Destroy an options object.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -517,12 +523,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#options_close.handle" name="options_close.handle"></a> `handle`: [`options`](#options)
 
 ##### Results
-- <a href="#options_close.error" name="options_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_close.error" name="options_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_close.error.ok" name="options_close.error.ok"></a> `ok`
+
+- <a href="#options_close.error.err" name="options_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> crypto_errno`
+#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> Result<(), crypto_errno>`
 Set or update an option.
 
 This is used to set algorithm-specific parameters, but also to provide credentials for the secrets management facilities, if required.
@@ -539,12 +554,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set.value_len" name="options_set.value_len"></a> `value_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set.error" name="options_set.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set.error" name="options_set.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set.error.ok" name="options_set.error.ok"></a> `ok`
+
+- <a href="#options_set.error.err" name="options_set.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> crypto_errno`
+#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> Result<(), crypto_errno>`
 Set or update an integer option.
 
 This is used to set algorithm-specific parameters.
@@ -559,12 +583,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_u64.value" name="options_set_u64.value"></a> `value`: `u64`
 
 ##### Results
-- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_u64.error.ok" name="options_set_u64.error.ok"></a> `ok`
+
+- <a href="#options_set_u64.error.err" name="options_set_u64.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> crypto_errno`
+#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> Result<(), crypto_errno>`
 Set or update a guest-allocated memory that the host can use or return data into.
 
 This is for example used to set the scratch buffer required by memory-hard functions.
@@ -581,12 +614,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_guest_buffer.buffer_len" name="options_set_guest_buffer.buffer_len"></a> `buffer_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_guest_buffer.error.ok" name="options_set_guest_buffer.error.ok"></a> `ok`
+
+- <a href="#options_set_guest_buffer.error.err" name="options_set_guest_buffer.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> (crypto_errno, size)`
+#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> Result<size, crypto_errno>`
 Return the length of an [`array_output`](#array_output) object.
 
 This allows a guest to allocate a buffer of the correct size in order to copy the output of a function returning this object type.
@@ -595,14 +637,21 @@ This allows a guest to allocate a buffer of the correct size in order to copy th
 - <a href="#array_output_len.array_output" name="array_output_len.array_output"></a> `array_output`: [`array_output`](#array_output)
 
 ##### Results
-- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_len.len" name="array_output_len.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_len.error.ok" name="array_output_len.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_len.error.err" name="array_output_len.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> (crypto_errno, size)`
+#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> Result<size, crypto_errno>`
 Copy the content of an [`array_output`](#array_output) object into an application-allocated buffer.
 
 Multiple calls to that function can be made in order to consume the data in a streaming fashion, if necessary.
@@ -627,14 +676,21 @@ array_output_pull(output_handle, &mut out)?;
 - <a href="#array_output_pull.buf_len" name="array_output_pull.buf_len"></a> `buf_len`: [`size`](#size)
 
 ##### Results
-- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_pull.len" name="array_output_pull.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_pull.error.ok" name="array_output_pull.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_pull.error.err" name="array_output_pull.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> (crypto_errno, secrets_manager)`
+#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> Result<secrets_manager, crypto_errno>`
 __(optional)__
 Create a context to use a secrets manager.
 
@@ -647,14 +703,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_open.options" name="secrets_manager_open.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: `Result<secrets_manager, crypto_errno>`
 
-- <a href="#secrets_manager_open.handle" name="secrets_manager_open.handle"></a> `handle`: [`secrets_manager`](#secrets_manager)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_open.error.ok" name="secrets_manager_open.error.ok"></a> `ok`: [`secrets_manager`](#secrets_manager)
+
+- <a href="#secrets_manager_open.error.err" name="secrets_manager_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> crypto_errno`
+#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> Result<(), crypto_errno>`
 __(optional)__
 Destroy a secrets manager context.
 
@@ -665,12 +728,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_close.secrets_manager" name="secrets_manager_close.secrets_manager"></a> `secrets_manager`: [`secrets_manager`](#secrets_manager)
 
 ##### Results
-- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_close.error.ok" name="secrets_manager_close.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_close.error.err" name="secrets_manager_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> crypto_errno`
+#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> Result<(), crypto_errno>`
 __(optional)__
 Invalidate a managed key or key pair given an identifier and a version.
 
@@ -692,7 +764,16 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_invalidate.key_version" name="secrets_manager_invalidate.key_version"></a> `key_version`: [`version`](#version)
 
 ##### Results
-- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_invalidate.error.ok" name="secrets_manager_invalidate.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_invalidate.error.err" name="secrets_manager_invalidate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 ## <a href="#wasi_ephemeral_crypto_symmetric" name="wasi_ephemeral_crypto_symmetric"></a> wasi_ephemeral_crypto_symmetric
 ### Imports
@@ -701,7 +782,7 @@ This is an optional import, meaning that the function may not even exist.
 
 ---
 
-#### <a href="#symmetric_key_generate" name="symmetric_key_generate"></a> `symmetric_key_generate(algorithm: string, options: opt_options) -> (crypto_errno, symmetric_key)`
+#### <a href="#symmetric_key_generate" name="symmetric_key_generate"></a> `symmetric_key_generate(algorithm: string, options: opt_options) -> Result<symmetric_key, crypto_errno>`
 Generate a new symmetric key for a given algorithm.
 
 [`options`](#options) can be `None` to use the default parameters, or an algoritm-specific set of parameters to override.
@@ -714,14 +795,21 @@ This function may return `unsupported_feature` if key generation is not supporte
 - <a href="#symmetric_key_generate.options" name="symmetric_key_generate.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#symmetric_key_generate.error" name="symmetric_key_generate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_generate.error" name="symmetric_key_generate.error"></a> `error`: `Result<symmetric_key, crypto_errno>`
 
-- <a href="#symmetric_key_generate.handle" name="symmetric_key_generate.handle"></a> `handle`: [`symmetric_key`](#symmetric_key)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_generate.error.ok" name="symmetric_key_generate.error.ok"></a> `ok`: [`symmetric_key`](#symmetric_key)
+
+- <a href="#symmetric_key_generate.error.err" name="symmetric_key_generate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_import" name="symmetric_key_import"></a> `symmetric_key_import(algorithm: string, raw: ConstPointer<u8>, raw_len: size) -> (crypto_errno, symmetric_key)`
+#### <a href="#symmetric_key_import" name="symmetric_key_import"></a> `symmetric_key_import(algorithm: string, raw: ConstPointer<u8>, raw_len: size) -> Result<symmetric_key, crypto_errno>`
 Create a symmetric key from raw material.
 
 The algorithm is internally stored along with the key, and trying to use the key with an operation expecting a different algorithm will return `invalid_key`.
@@ -736,14 +824,21 @@ The function may also return `unsupported_algorithm` if the algorithm is not sup
 - <a href="#symmetric_key_import.raw_len" name="symmetric_key_import.raw_len"></a> `raw_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_key_import.error" name="symmetric_key_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_import.error" name="symmetric_key_import.error"></a> `error`: `Result<symmetric_key, crypto_errno>`
 
-- <a href="#symmetric_key_import.handle" name="symmetric_key_import.handle"></a> `handle`: [`symmetric_key`](#symmetric_key)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_import.error.ok" name="symmetric_key_import.error.ok"></a> `ok`: [`symmetric_key`](#symmetric_key)
+
+- <a href="#symmetric_key_import.error.err" name="symmetric_key_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_export" name="symmetric_key_export"></a> `symmetric_key_export(symmetric_key: symmetric_key) -> (crypto_errno, array_output)`
+#### <a href="#symmetric_key_export" name="symmetric_key_export"></a> `symmetric_key_export(symmetric_key: symmetric_key) -> Result<array_output, crypto_errno>`
 Export a symmetric key as raw material.
 
 This is mainly useful to export a managed key.
@@ -754,14 +849,21 @@ May return `prohibited_operation` if this operation is denied.
 - <a href="#symmetric_key_export.symmetric_key" name="symmetric_key_export.symmetric_key"></a> `symmetric_key`: [`symmetric_key`](#symmetric_key)
 
 ##### Results
-- <a href="#symmetric_key_export.error" name="symmetric_key_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_export.error" name="symmetric_key_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#symmetric_key_export.encoded" name="symmetric_key_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_export.error.ok" name="symmetric_key_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#symmetric_key_export.error.err" name="symmetric_key_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_close" name="symmetric_key_close"></a> `symmetric_key_close(symmetric_key: symmetric_key) -> crypto_errno`
+#### <a href="#symmetric_key_close" name="symmetric_key_close"></a> `symmetric_key_close(symmetric_key: symmetric_key) -> Result<(), crypto_errno>`
 Destroy a symmetric key.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -770,12 +872,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#symmetric_key_close.symmetric_key" name="symmetric_key_close.symmetric_key"></a> `symmetric_key`: [`symmetric_key`](#symmetric_key)
 
 ##### Results
-- <a href="#symmetric_key_close.error" name="symmetric_key_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_close.error" name="symmetric_key_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_close.error.ok" name="symmetric_key_close.error.ok"></a> `ok`
+
+- <a href="#symmetric_key_close.error.err" name="symmetric_key_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_generate_managed" name="symmetric_key_generate_managed"></a> `symmetric_key_generate_managed(secrets_manager: secrets_manager, algorithm: string, options: opt_options) -> (crypto_errno, symmetric_key)`
+#### <a href="#symmetric_key_generate_managed" name="symmetric_key_generate_managed"></a> `symmetric_key_generate_managed(secrets_manager: secrets_manager, algorithm: string, options: opt_options) -> Result<symmetric_key, crypto_errno>`
 __(optional)__
 Generate a new managed symmetric key.
 
@@ -798,14 +909,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#symmetric_key_generate_managed.options" name="symmetric_key_generate_managed.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#symmetric_key_generate_managed.error" name="symmetric_key_generate_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_generate_managed.error" name="symmetric_key_generate_managed.error"></a> `error`: `Result<symmetric_key, crypto_errno>`
 
-- <a href="#symmetric_key_generate_managed.handle" name="symmetric_key_generate_managed.handle"></a> `handle`: [`symmetric_key`](#symmetric_key)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_generate_managed.error.ok" name="symmetric_key_generate_managed.error.ok"></a> `ok`: [`symmetric_key`](#symmetric_key)
+
+- <a href="#symmetric_key_generate_managed.error.err" name="symmetric_key_generate_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_store_managed" name="symmetric_key_store_managed"></a> `symmetric_key_store_managed(secrets_manager: secrets_manager, symmetric_key: symmetric_key, symmetric_key_id: Pointer<u8>, symmetric_key_id_max_len: size) -> crypto_errno`
+#### <a href="#symmetric_key_store_managed" name="symmetric_key_store_managed"></a> `symmetric_key_store_managed(secrets_manager: secrets_manager, symmetric_key: symmetric_key, symmetric_key_id: Pointer<u8>, symmetric_key_id_max_len: size) -> Result<(), crypto_errno>`
 __(optional)__
 Store a symmetric key into the secrets manager.
 
@@ -824,12 +942,21 @@ The function returns `overflow` if the supplied buffer is too small.
 - <a href="#symmetric_key_store_managed.symmetric_key_id_max_len" name="symmetric_key_store_managed.symmetric_key_id_max_len"></a> `symmetric_key_id_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_key_store_managed.error" name="symmetric_key_store_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_store_managed.error" name="symmetric_key_store_managed.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_store_managed.error.ok" name="symmetric_key_store_managed.error.ok"></a> `ok`
+
+- <a href="#symmetric_key_store_managed.error.err" name="symmetric_key_store_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_replace_managed" name="symmetric_key_replace_managed"></a> `symmetric_key_replace_managed(secrets_manager: secrets_manager, symmetric_key_old: symmetric_key, symmetric_key_new: symmetric_key) -> (crypto_errno, version)`
+#### <a href="#symmetric_key_replace_managed" name="symmetric_key_replace_managed"></a> `symmetric_key_replace_managed(secrets_manager: secrets_manager, symmetric_key_old: symmetric_key, symmetric_key_new: symmetric_key) -> Result<version, crypto_errno>`
 __(optional)__
 Replace a managed symmetric key.
 
@@ -860,14 +987,21 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#symmetric_key_replace_managed.symmetric_key_new" name="symmetric_key_replace_managed.symmetric_key_new"></a> `symmetric_key_new`: [`symmetric_key`](#symmetric_key)
 
 ##### Results
-- <a href="#symmetric_key_replace_managed.error" name="symmetric_key_replace_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_replace_managed.error" name="symmetric_key_replace_managed.error"></a> `error`: `Result<version, crypto_errno>`
 
-- <a href="#symmetric_key_replace_managed.version" name="symmetric_key_replace_managed.version"></a> `version`: [`version`](#version)
+###### Variant Layout
+- size: 16
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_replace_managed.error.ok" name="symmetric_key_replace_managed.error.ok"></a> `ok`: [`version`](#version)
+
+- <a href="#symmetric_key_replace_managed.error.err" name="symmetric_key_replace_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_id" name="symmetric_key_id"></a> `symmetric_key_id(symmetric_key: symmetric_key, symmetric_key_id: Pointer<u8>, symmetric_key_id_max_len: size) -> (crypto_errno, size, version)`
+#### <a href="#symmetric_key_id" name="symmetric_key_id"></a> `symmetric_key_id(symmetric_key: symmetric_key, symmetric_key_id: Pointer<u8>, symmetric_key_id_max_len: size) -> Result<(size, version), crypto_errno>`
 __(optional)__
 Return the key identifier and version of a managed symmetric key.
 
@@ -883,16 +1017,30 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#symmetric_key_id.symmetric_key_id_max_len" name="symmetric_key_id.symmetric_key_id_max_len"></a> `symmetric_key_id_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_key_id.error" name="symmetric_key_id.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_id.error" name="symmetric_key_id.error"></a> `error`: `Result<(size, version), crypto_errno>`
 
-- <a href="#symmetric_key_id.symmetric_key_id_len" name="symmetric_key_id.symmetric_key_id_len"></a> `symmetric_key_id_len`: [`size`](#size)
+###### Variant Layout
+- size: 24
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_id.error.ok" name="symmetric_key_id.error.ok"></a> `ok`: `(size, version)`
 
-- <a href="#symmetric_key_id.version" name="symmetric_key_id.version"></a> `version`: [`version`](#version)
+####### Record members
+- <a href="#symmetric_key_id.error.ok.0" name="symmetric_key_id.error.ok.0"></a> `0`: [`size`](#size)
+
+Offset: 0
+
+- <a href="#symmetric_key_id.error.ok.1" name="symmetric_key_id.error.ok.1"></a> `1`: [`version`](#version)
+
+Offset: 8
+
+- <a href="#symmetric_key_id.error.err" name="symmetric_key_id.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_from_id" name="symmetric_key_from_id"></a> `symmetric_key_from_id(secrets_manager: secrets_manager, symmetric_key_id: ConstPointer<u8>, symmetric_key_id_len: size, symmetric_key_version: version) -> (crypto_errno, symmetric_key)`
+#### <a href="#symmetric_key_from_id" name="symmetric_key_from_id"></a> `symmetric_key_from_id(secrets_manager: secrets_manager, symmetric_key_id: ConstPointer<u8>, symmetric_key_id_len: size, symmetric_key_version: version) -> Result<symmetric_key, crypto_errno>`
 __(optional)__
 Return a managed symmetric key from a key identifier.
 
@@ -912,14 +1060,21 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#symmetric_key_from_id.symmetric_key_version" name="symmetric_key_from_id.symmetric_key_version"></a> `symmetric_key_version`: [`version`](#version)
 
 ##### Results
-- <a href="#symmetric_key_from_id.error" name="symmetric_key_from_id.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_from_id.error" name="symmetric_key_from_id.error"></a> `error`: `Result<symmetric_key, crypto_errno>`
 
-- <a href="#symmetric_key_from_id.handle" name="symmetric_key_from_id.handle"></a> `handle`: [`symmetric_key`](#symmetric_key)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_from_id.error.ok" name="symmetric_key_from_id.error.ok"></a> `ok`: [`symmetric_key`](#symmetric_key)
+
+- <a href="#symmetric_key_from_id.error.err" name="symmetric_key_from_id.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_open" name="symmetric_state_open"></a> `symmetric_state_open(algorithm: string, key: opt_symmetric_key, options: opt_options) -> (crypto_errno, symmetric_state)`
+#### <a href="#symmetric_state_open" name="symmetric_state_open"></a> `symmetric_state_open(algorithm: string, key: opt_symmetric_key, options: opt_options) -> Result<symmetric_state, crypto_errno>`
 Create a new state to aborb and produce data using symmetric operations.
 
 The state remains valid after every operation in order to support incremental updates.
@@ -1105,14 +1260,21 @@ let next_key_handle = ctx.symmetric_state_squeeze_key(state_handle, "Xoodyak-128
 - <a href="#symmetric_state_open.options" name="symmetric_state_open.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#symmetric_state_open.error" name="symmetric_state_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_open.error" name="symmetric_state_open.error"></a> `error`: `Result<symmetric_state, crypto_errno>`
 
-- <a href="#symmetric_state_open.symmetric_state" name="symmetric_state_open.symmetric_state"></a> `symmetric_state`: [`symmetric_state`](#symmetric_state)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_open.error.ok" name="symmetric_state_open.error.ok"></a> `ok`: [`symmetric_state`](#symmetric_state)
+
+- <a href="#symmetric_state_open.error.err" name="symmetric_state_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_options_get" name="symmetric_state_options_get"></a> `symmetric_state_options_get(handle: symmetric_state, name: string, value: Pointer<u8>, value_max_len: size) -> (crypto_errno, size)`
+#### <a href="#symmetric_state_options_get" name="symmetric_state_options_get"></a> `symmetric_state_options_get(handle: symmetric_state, name: string, value: Pointer<u8>, value_max_len: size) -> Result<size, crypto_errno>`
 Retrieve a parameter from the current state.
 
 In particular, `symmetric_state_options_get("nonce")` can be used to get a nonce that as automatically generated.
@@ -1131,14 +1293,21 @@ It may also return `unsupported_option` if the option doesn't exist for the chos
 - <a href="#symmetric_state_options_get.value_max_len" name="symmetric_state_options_get.value_max_len"></a> `value_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_options_get.error" name="symmetric_state_options_get.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_options_get.error" name="symmetric_state_options_get.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_state_options_get.value_len" name="symmetric_state_options_get.value_len"></a> `value_len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_options_get.error.ok" name="symmetric_state_options_get.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_state_options_get.error.err" name="symmetric_state_options_get.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_options_get_u64" name="symmetric_state_options_get_u64"></a> `symmetric_state_options_get_u64(handle: symmetric_state, name: string) -> (crypto_errno, u64)`
+#### <a href="#symmetric_state_options_get_u64" name="symmetric_state_options_get_u64"></a> `symmetric_state_options_get_u64(handle: symmetric_state, name: string) -> Result<u64, crypto_errno>`
 Retrieve an integer parameter from the current state.
 
 In particular, `symmetric_state_options_get("nonce")` can be used to get a nonce that as automatically generated.
@@ -1153,14 +1322,21 @@ It may also return `unsupported_option` if the option doesn't exist for the chos
 - <a href="#symmetric_state_options_get_u64.name" name="symmetric_state_options_get_u64.name"></a> `name`: `string`
 
 ##### Results
-- <a href="#symmetric_state_options_get_u64.error" name="symmetric_state_options_get_u64.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_options_get_u64.error" name="symmetric_state_options_get_u64.error"></a> `error`: `Result<u64, crypto_errno>`
 
-- <a href="#symmetric_state_options_get_u64.value" name="symmetric_state_options_get_u64.value"></a> `value`: `u64`
+###### Variant Layout
+- size: 16
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_options_get_u64.error.ok" name="symmetric_state_options_get_u64.error.ok"></a> `ok`: [`u64`](#u64)
+
+- <a href="#symmetric_state_options_get_u64.error.err" name="symmetric_state_options_get_u64.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_close" name="symmetric_state_close"></a> `symmetric_state_close(handle: symmetric_state) -> crypto_errno`
+#### <a href="#symmetric_state_close" name="symmetric_state_close"></a> `symmetric_state_close(handle: symmetric_state) -> Result<(), crypto_errno>`
 Destroy a symmetric state.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1169,12 +1345,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#symmetric_state_close.handle" name="symmetric_state_close.handle"></a> `handle`: [`symmetric_state`](#symmetric_state)
 
 ##### Results
-- <a href="#symmetric_state_close.error" name="symmetric_state_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_close.error" name="symmetric_state_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_close.error.ok" name="symmetric_state_close.error.ok"></a> `ok`
+
+- <a href="#symmetric_state_close.error.err" name="symmetric_state_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_absorb" name="symmetric_state_absorb"></a> `symmetric_state_absorb(handle: symmetric_state, data: ConstPointer<u8>, data_len: size) -> crypto_errno`
+#### <a href="#symmetric_state_absorb" name="symmetric_state_absorb"></a> `symmetric_state_absorb(handle: symmetric_state, data: ConstPointer<u8>, data_len: size) -> Result<(), crypto_errno>`
 Absorb data into the state.
 
 - **Hash functions:** adds data to be hashed.
@@ -1196,12 +1381,21 @@ If too much data has been fed for the algorithm, `overflow` may be thrown.
 - <a href="#symmetric_state_absorb.data_len" name="symmetric_state_absorb.data_len"></a> `data_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_absorb.error" name="symmetric_state_absorb.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_absorb.error" name="symmetric_state_absorb.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_absorb.error.ok" name="symmetric_state_absorb.error.ok"></a> `ok`
+
+- <a href="#symmetric_state_absorb.error.err" name="symmetric_state_absorb.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_squeeze" name="symmetric_state_squeeze"></a> `symmetric_state_squeeze(handle: symmetric_state, out: Pointer<u8>, out_len: size) -> crypto_errno`
+#### <a href="#symmetric_state_squeeze" name="symmetric_state_squeeze"></a> `symmetric_state_squeeze(handle: symmetric_state, out: Pointer<u8>, out_len: size) -> Result<(), crypto_errno>`
 Squeeze bytes from the state.
 
 - **Hash functions:** this tries to output an `out_len` bytes digest from the absorbed data. The hash function output will be truncated if necessary. If the requested size is too large, the `invalid_len` error code is returned.
@@ -1222,12 +1416,21 @@ In that case, the guest should retry with the same parameters until the function
 - <a href="#symmetric_state_squeeze.out_len" name="symmetric_state_squeeze.out_len"></a> `out_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_squeeze.error" name="symmetric_state_squeeze.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_squeeze.error" name="symmetric_state_squeeze.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_squeeze.error.ok" name="symmetric_state_squeeze.error.ok"></a> `ok`
+
+- <a href="#symmetric_state_squeeze.error.err" name="symmetric_state_squeeze.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_squeeze_tag" name="symmetric_state_squeeze_tag"></a> `symmetric_state_squeeze_tag(handle: symmetric_state) -> (crypto_errno, symmetric_tag)`
+#### <a href="#symmetric_state_squeeze_tag" name="symmetric_state_squeeze_tag"></a> `symmetric_state_squeeze_tag(handle: symmetric_state) -> Result<symmetric_tag, crypto_errno>`
 Compute and return a tag for all the data injected into the state so far.
 
 - **MAC functions**: returns a tag authenticating the absorbed data.
@@ -1243,14 +1446,21 @@ In that case, the guest should retry with the same parameters until the function
 - <a href="#symmetric_state_squeeze_tag.handle" name="symmetric_state_squeeze_tag.handle"></a> `handle`: [`symmetric_state`](#symmetric_state)
 
 ##### Results
-- <a href="#symmetric_state_squeeze_tag.error" name="symmetric_state_squeeze_tag.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_squeeze_tag.error" name="symmetric_state_squeeze_tag.error"></a> `error`: `Result<symmetric_tag, crypto_errno>`
 
-- <a href="#symmetric_state_squeeze_tag.symmetric_tag" name="symmetric_state_squeeze_tag.symmetric_tag"></a> `symmetric_tag`: [`symmetric_tag`](#symmetric_tag)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_squeeze_tag.error.ok" name="symmetric_state_squeeze_tag.error.ok"></a> `ok`: [`symmetric_tag`](#symmetric_tag)
+
+- <a href="#symmetric_state_squeeze_tag.error.err" name="symmetric_state_squeeze_tag.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_squeeze_key" name="symmetric_state_squeeze_key"></a> `symmetric_state_squeeze_key(handle: symmetric_state, alg_str: string) -> (crypto_errno, symmetric_key)`
+#### <a href="#symmetric_state_squeeze_key" name="symmetric_state_squeeze_key"></a> `symmetric_state_squeeze_key(handle: symmetric_state, alg_str: string) -> Result<symmetric_key, crypto_errno>`
 Use the current state to produce a key for a target algorithm.
 
 For extract-then-expand constructions, this returns the PRK.
@@ -1264,14 +1474,21 @@ For session-base authentication encryption, this returns a key that can be used 
 - <a href="#symmetric_state_squeeze_key.alg_str" name="symmetric_state_squeeze_key.alg_str"></a> `alg_str`: `string`
 
 ##### Results
-- <a href="#symmetric_state_squeeze_key.error" name="symmetric_state_squeeze_key.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_squeeze_key.error" name="symmetric_state_squeeze_key.error"></a> `error`: `Result<symmetric_key, crypto_errno>`
 
-- <a href="#symmetric_state_squeeze_key.symmetric_key" name="symmetric_state_squeeze_key.symmetric_key"></a> `symmetric_key`: [`symmetric_key`](#symmetric_key)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_squeeze_key.error.ok" name="symmetric_state_squeeze_key.error.ok"></a> `ok`: [`symmetric_key`](#symmetric_key)
+
+- <a href="#symmetric_state_squeeze_key.error.err" name="symmetric_state_squeeze_key.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_max_tag_len" name="symmetric_state_max_tag_len"></a> `symmetric_state_max_tag_len(handle: symmetric_state) -> (crypto_errno, size)`
+#### <a href="#symmetric_state_max_tag_len" name="symmetric_state_max_tag_len"></a> `symmetric_state_max_tag_len(handle: symmetric_state) -> Result<size, crypto_errno>`
 Return the maximum length of an authentication tag for the current algorithm.
 
 This allows guests to compute the size required to store a ciphertext along with its authentication tag.
@@ -1286,14 +1503,21 @@ For a decryption operation, the size of the buffer that will store the decrypted
 - <a href="#symmetric_state_max_tag_len.handle" name="symmetric_state_max_tag_len.handle"></a> `handle`: [`symmetric_state`](#symmetric_state)
 
 ##### Results
-- <a href="#symmetric_state_max_tag_len.error" name="symmetric_state_max_tag_len.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_max_tag_len.error" name="symmetric_state_max_tag_len.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_state_max_tag_len.len" name="symmetric_state_max_tag_len.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_max_tag_len.error.ok" name="symmetric_state_max_tag_len.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_state_max_tag_len.error.err" name="symmetric_state_max_tag_len.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_encrypt" name="symmetric_state_encrypt"></a> `symmetric_state_encrypt(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size) -> (crypto_errno, size)`
+#### <a href="#symmetric_state_encrypt" name="symmetric_state_encrypt"></a> `symmetric_state_encrypt(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size) -> Result<size, crypto_errno>`
 Encrypt data with an attached tag.
 
 - **Stream cipher:** adds the input to the stream cipher output. `out_len` and `data_len` can be equal, as no authentication tags will be added.
@@ -1318,14 +1542,21 @@ The function returns the actual size of the ciphertext along with the tag.
 - <a href="#symmetric_state_encrypt.data_len" name="symmetric_state_encrypt.data_len"></a> `data_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_encrypt.error" name="symmetric_state_encrypt.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_encrypt.error" name="symmetric_state_encrypt.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_state_encrypt.actual_out_len" name="symmetric_state_encrypt.actual_out_len"></a> `actual_out_len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_encrypt.error.ok" name="symmetric_state_encrypt.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_state_encrypt.error.err" name="symmetric_state_encrypt.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_encrypt_detached" name="symmetric_state_encrypt_detached"></a> `symmetric_state_encrypt_detached(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size) -> (crypto_errno, symmetric_tag)`
+#### <a href="#symmetric_state_encrypt_detached" name="symmetric_state_encrypt_detached"></a> `symmetric_state_encrypt_detached(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size) -> Result<symmetric_tag, crypto_errno>`
 Encrypt data, with a detached tag.
 
 - **Stream cipher:** returns `invalid_operation` since stream ciphers do not include authentication tags.
@@ -1350,14 +1581,21 @@ The function returns the tag.
 - <a href="#symmetric_state_encrypt_detached.data_len" name="symmetric_state_encrypt_detached.data_len"></a> `data_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_encrypt_detached.error" name="symmetric_state_encrypt_detached.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_encrypt_detached.error" name="symmetric_state_encrypt_detached.error"></a> `error`: `Result<symmetric_tag, crypto_errno>`
 
-- <a href="#symmetric_state_encrypt_detached.symmetric_tag" name="symmetric_state_encrypt_detached.symmetric_tag"></a> `symmetric_tag`: [`symmetric_tag`](#symmetric_tag)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_encrypt_detached.error.ok" name="symmetric_state_encrypt_detached.error.ok"></a> `ok`: [`symmetric_tag`](#symmetric_tag)
+
+- <a href="#symmetric_state_encrypt_detached.error.err" name="symmetric_state_encrypt_detached.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_decrypt" name="symmetric_state_decrypt"></a> `symmetric_state_decrypt(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size) -> (crypto_errno, size)`
+#### <a href="#symmetric_state_decrypt" name="symmetric_state_decrypt"></a> `symmetric_state_decrypt(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size) -> Result<size, crypto_errno>`
 - **Stream cipher:** adds the input to the stream cipher output. `out_len` and `data_len` can be equal, as no authentication tags will be added.
 - **AEAD:** decrypts `data` into `out`. Additional data must have been previously absorbed using `symmetric_state_absorb()`.
 - **SHOE, Xoodyak, Strobe:** decrypts data, squeezes a tag and verify that it matches the one that was appended to the ciphertext.
@@ -1384,14 +1622,21 @@ The function returns the actual size of the decrypted message, which can be smal
 - <a href="#symmetric_state_decrypt.data_len" name="symmetric_state_decrypt.data_len"></a> `data_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_decrypt.error" name="symmetric_state_decrypt.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_decrypt.error" name="symmetric_state_decrypt.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_state_decrypt.actual_out_len" name="symmetric_state_decrypt.actual_out_len"></a> `actual_out_len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_decrypt.error.ok" name="symmetric_state_decrypt.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_state_decrypt.error.err" name="symmetric_state_decrypt.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_decrypt_detached" name="symmetric_state_decrypt_detached"></a> `symmetric_state_decrypt_detached(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size, raw_tag: ConstPointer<u8>, raw_tag_len: size) -> (crypto_errno, size)`
+#### <a href="#symmetric_state_decrypt_detached" name="symmetric_state_decrypt_detached"></a> `symmetric_state_decrypt_detached(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size, raw_tag: ConstPointer<u8>, raw_tag_len: size) -> Result<size, crypto_errno>`
 - **Stream cipher:** returns `invalid_operation` since stream ciphers do not include authentication tags.
 - **AEAD:** decrypts `data` into `out`. Additional data must have been previously absorbed using `symmetric_state_absorb()`.
 - **SHOE, Xoodyak, Strobe:** decrypts data, squeezes a tag and verify that it matches the expected one.
@@ -1423,14 +1668,21 @@ The function returns the actual size of the decrypted message.
 - <a href="#symmetric_state_decrypt_detached.raw_tag_len" name="symmetric_state_decrypt_detached.raw_tag_len"></a> `raw_tag_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_decrypt_detached.error" name="symmetric_state_decrypt_detached.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_decrypt_detached.error" name="symmetric_state_decrypt_detached.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_state_decrypt_detached.actual_out_len" name="symmetric_state_decrypt_detached.actual_out_len"></a> `actual_out_len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_decrypt_detached.error.ok" name="symmetric_state_decrypt_detached.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_state_decrypt_detached.error.err" name="symmetric_state_decrypt_detached.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_ratchet" name="symmetric_state_ratchet"></a> `symmetric_state_ratchet(handle: symmetric_state) -> crypto_errno`
+#### <a href="#symmetric_state_ratchet" name="symmetric_state_ratchet"></a> `symmetric_state_ratchet(handle: symmetric_state) -> Result<(), crypto_errno>`
 Make it impossible to recover the previous state.
 
 This operation is supported by some systems keeping a rolling state over an entire session, for forward security.
@@ -1441,12 +1693,21 @@ This operation is supported by some systems keeping a rolling state over an enti
 - <a href="#symmetric_state_ratchet.handle" name="symmetric_state_ratchet.handle"></a> `handle`: [`symmetric_state`](#symmetric_state)
 
 ##### Results
-- <a href="#symmetric_state_ratchet.error" name="symmetric_state_ratchet.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_ratchet.error" name="symmetric_state_ratchet.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_ratchet.error.ok" name="symmetric_state_ratchet.error.ok"></a> `ok`
+
+- <a href="#symmetric_state_ratchet.error.err" name="symmetric_state_ratchet.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_tag_len" name="symmetric_tag_len"></a> `symmetric_tag_len(symmetric_tag: symmetric_tag) -> (crypto_errno, size)`
+#### <a href="#symmetric_tag_len" name="symmetric_tag_len"></a> `symmetric_tag_len(symmetric_tag: symmetric_tag) -> Result<size, crypto_errno>`
 Return the length of an authentication tag.
 
 This function can be used by a guest to allocate the correct buffer size to copy a computed authentication tag.
@@ -1455,14 +1716,21 @@ This function can be used by a guest to allocate the correct buffer size to copy
 - <a href="#symmetric_tag_len.symmetric_tag" name="symmetric_tag_len.symmetric_tag"></a> `symmetric_tag`: [`symmetric_tag`](#symmetric_tag)
 
 ##### Results
-- <a href="#symmetric_tag_len.error" name="symmetric_tag_len.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_tag_len.error" name="symmetric_tag_len.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_tag_len.len" name="symmetric_tag_len.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_tag_len.error.ok" name="symmetric_tag_len.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_tag_len.error.err" name="symmetric_tag_len.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_tag_pull" name="symmetric_tag_pull"></a> `symmetric_tag_pull(symmetric_tag: symmetric_tag, buf: Pointer<u8>, buf_len: size) -> (crypto_errno, size)`
+#### <a href="#symmetric_tag_pull" name="symmetric_tag_pull"></a> `symmetric_tag_pull(symmetric_tag: symmetric_tag, buf: Pointer<u8>, buf_len: size) -> Result<size, crypto_errno>`
 Copy an authentication tag into a guest-allocated buffer.
 
 The handle automatically becomes invalid after this operation. Manually closing it is not required.
@@ -1486,14 +1754,21 @@ Otherwise, it returns the number of bytes that have been copied.
 - <a href="#symmetric_tag_pull.buf_len" name="symmetric_tag_pull.buf_len"></a> `buf_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_tag_pull.error" name="symmetric_tag_pull.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_tag_pull.error" name="symmetric_tag_pull.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_tag_pull.len" name="symmetric_tag_pull.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_tag_pull.error.ok" name="symmetric_tag_pull.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_tag_pull.error.err" name="symmetric_tag_pull.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_tag_verify" name="symmetric_tag_verify"></a> `symmetric_tag_verify(symmetric_tag: symmetric_tag, expected_raw_tag_ptr: ConstPointer<u8>, expected_raw_tag_len: size) -> crypto_errno`
+#### <a href="#symmetric_tag_verify" name="symmetric_tag_verify"></a> `symmetric_tag_verify(symmetric_tag: symmetric_tag, expected_raw_tag_ptr: ConstPointer<u8>, expected_raw_tag_len: size) -> Result<(), crypto_errno>`
 Verify that a computed authentication tag matches the expected value, in constant-time.
 
 The expected tag must be provided as a raw byte string.
@@ -1518,12 +1793,21 @@ ctx.symmetric_tag_verify(computed_tag_handle, expected_raw_tag)?;
 - <a href="#symmetric_tag_verify.expected_raw_tag_len" name="symmetric_tag_verify.expected_raw_tag_len"></a> `expected_raw_tag_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_tag_verify.error" name="symmetric_tag_verify.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_tag_verify.error" name="symmetric_tag_verify.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_tag_verify.error.ok" name="symmetric_tag_verify.error.ok"></a> `ok`
+
+- <a href="#symmetric_tag_verify.error.err" name="symmetric_tag_verify.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_tag_close" name="symmetric_tag_close"></a> `symmetric_tag_close(symmetric_tag: symmetric_tag) -> crypto_errno`
+#### <a href="#symmetric_tag_close" name="symmetric_tag_close"></a> `symmetric_tag_close(symmetric_tag: symmetric_tag) -> Result<(), crypto_errno>`
 Explicitly destroy an unused authentication tag.
 
 This is usually not necessary, as `symmetric_tag_pull()` automatically closes a tag after it has been copied.
@@ -1534,5 +1818,15 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#symmetric_tag_close.symmetric_tag" name="symmetric_tag_close.symmetric_tag"></a> `symmetric_tag`: [`symmetric_tag`](#symmetric_tag)
 
 ##### Results
-- <a href="#symmetric_tag_close.error" name="symmetric_tag_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_tag_close.error" name="symmetric_tag_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_tag_close.error.ok" name="symmetric_tag_close.error.ok"></a> `ok`
+
+- <a href="#symmetric_tag_close.error.err" name="symmetric_tag_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
+
 

--- a/witx/proposal_symmetric.witx
+++ b/witx/proposal_symmetric.witx
@@ -13,8 +13,7 @@
   (@interface func (export "symmetric_key_generate")
     (param $algorithm string)
     (param $options $opt_options)
-    (result $error $crypto_errno)
-    (result $handle $symmetric_key)
+    (result $error (expected $symmetric_key (error $crypto_errno)))
   )
 
   ;;; Create a symmetric key from raw material.
@@ -26,8 +25,7 @@
     (param $algorithm string)
     (param $raw (@witx const_pointer u8))
     (param $raw_len $size)
-    (result $error $crypto_errno)
-    (result $handle $symmetric_key)
+    (result $error (expected $symmetric_key (error $crypto_errno)))
   )
 
   ;;; Export a symmetric key as raw material.
@@ -37,8 +35,7 @@
   ;;; May return `prohibited_operation` if this operation is denied.
   (@interface func (export "symmetric_key_export")
     (param $symmetric_key $symmetric_key)
-    (result $error $crypto_errno)
-    (result $encoded $array_output)
+    (result $error (expected $array_output (error $crypto_errno)))
   )
 
   ;;; Destroy a symmetric key.
@@ -46,7 +43,7 @@
   ;;; Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
   (@interface func (export "symmetric_key_close")
     (param $symmetric_key $symmetric_key)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -66,8 +63,7 @@
     (param $secrets_manager $secrets_manager)
     (param $algorithm string)
     (param $options $opt_options)
-    (result $error $crypto_errno)
-    (result $handle $symmetric_key)
+    (result $error (expected $symmetric_key (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -82,7 +78,7 @@
     (param $symmetric_key $symmetric_key)
     (param $symmetric_key_id (@witx pointer u8))
     (param $symmetric_key_id_max_len $size)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -110,8 +106,7 @@
     (param $secrets_manager $secrets_manager)
     (param $symmetric_key_old $symmetric_key)
     (param $symmetric_key_new $symmetric_key)
-    (result $error $crypto_errno)
-    (result $version $version)
+    (result $error (expected $version (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -124,9 +119,7 @@
     (param $symmetric_key $symmetric_key)
     (param $symmetric_key_id (@witx pointer u8))
     (param $symmetric_key_id_max_len $size)
-    (result $error $crypto_errno)
-    (result $symmetric_key_id_len $size)
-    (result $version $version)
+    (result $error (expected (tuple $size $version) (error $crypto_errno)))
   )
 
   ;;; __(optional)__
@@ -142,8 +135,7 @@
     (param $symmetric_key_id (@witx const_pointer u8))
     (param $symmetric_key_id_len $size)
     (param $symmetric_key_version $version)
-    (result $error $crypto_errno)
-    (result $handle $symmetric_key)
+    (result $error (expected $symmetric_key (error $crypto_errno)))
   )
 
   ;;; Create a new state to aborb and produce data using symmetric operations.
@@ -327,8 +319,7 @@
     (param $algorithm string)
     (param $key $opt_symmetric_key)
     (param $options $opt_options)
-    (result $error $crypto_errno)
-    (result $symmetric_state $symmetric_state)
+    (result $error (expected $symmetric_state (error $crypto_errno)))
   )
 
   ;;; Retrieve a parameter from the current state.
@@ -343,8 +334,7 @@
     (param $name string)
     (param $value (@witx pointer u8))
     (param $value_max_len $size)
-    (result $error $crypto_errno)
-    (result $value_len $size)
+    (result $error (expected $size (error $crypto_errno)))
   )
 
   ;;; Retrieve an integer parameter from the current state.
@@ -357,8 +347,7 @@
   (@interface func (export "symmetric_state_options_get_u64")
     (param $handle $symmetric_state)
     (param $name string)
-    (result $error $crypto_errno)
-    (result $value u64)
+    (result $error (expected $u64 (error $crypto_errno)))
   )
 
   ;;; Destroy a symmetric state.
@@ -366,7 +355,7 @@
   ;;; Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
   (@interface func (export "symmetric_state_close")
     (param $handle $symmetric_state)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Absorb data into the state.
@@ -385,7 +374,7 @@
     (param $handle $symmetric_state)
     (param $data (@witx const_pointer u8))
     (param $data_len $size)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Squeeze bytes from the state.
@@ -403,7 +392,7 @@
     (param $handle $symmetric_state)
     (param $out (@witx pointer u8))
     (param $out_len $size)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Compute and return a tag for all the data injected into the state so far.
@@ -418,8 +407,7 @@
   ;;; In that case, the guest should retry with the same parameters until the function completes.
   (@interface func (export "symmetric_state_squeeze_tag")
     (param $handle $symmetric_state)
-    (result $error $crypto_errno)
-    (result $symmetric_tag $symmetric_tag)
+    (result $error (expected $symmetric_tag (error $crypto_errno)))
   )
 
   ;;; Use the current state to produce a key for a target algorithm.
@@ -431,8 +419,7 @@
   (@interface func (export "symmetric_state_squeeze_key")
     (param $handle $symmetric_state)
     (param $alg_str string)
-    (result $error $crypto_errno)
-    (result $symmetric_key $symmetric_key)
+    (result $error (expected $symmetric_key (error $crypto_errno)))
   )
 
   ;;; Return the maximum length of an authentication tag for the current algorithm.
@@ -446,8 +433,7 @@
   ;;; For a decryption operation, the size of the buffer that will store the decrypted data must be `ciphertext_len - symmetric_state_max_tag_len()`.
   (@interface func (export "symmetric_state_max_tag_len")
     (param $handle $symmetric_state)
-    (result $error $crypto_errno)
-    (result $len $size)
+    (result $error (expected $size (error $crypto_errno)))
   )
 
   ;;; Encrypt data with an attached tag.
@@ -467,8 +453,7 @@
     (param $out_len $size)
     (param $data (@witx const_pointer u8))
     (param $data_len $size)
-    (result $error $crypto_errno)
-    (result $actual_out_len $size)
+    (result $error (expected $size (error $crypto_errno)))
   )
 
   ;;; Encrypt data, with a detached tag.
@@ -488,8 +473,7 @@
     (param $out_len $size)
     (param $data (@witx const_pointer u8))
     (param $data_len $size)
-    (result $error $crypto_errno)
-    (result $symmetric_tag $symmetric_tag)
+    (result $error (expected $symmetric_tag (error $crypto_errno)))
   )
 
   ;;; - **Stream cipher:** adds the input to the stream cipher output. `out_len` and `data_len` can be equal, as no authentication tags will be added.
@@ -511,8 +495,7 @@
     (param $out_len $size)
     (param $data (@witx const_pointer u8))
     (param $data_len $size)
-    (result $error $crypto_errno)
-    (result $actual_out_len $size)
+    (result $error (expected $size (error $crypto_errno)))
   )
 
   ;;; - **Stream cipher:** returns `invalid_operation` since stream ciphers do not include authentication tags.
@@ -537,8 +520,7 @@
     (param $data_len $size)
     (param $raw_tag (@witx const_pointer u8))
     (param $raw_tag_len $size)
-    (result $error $crypto_errno)
-    (result $actual_out_len $size)
+    (result $error (expected $size (error $crypto_errno)))
   )
 
   ;;; Make it impossible to recover the previous state.
@@ -548,7 +530,7 @@
   ;;; `invalid_operation` is returned for algorithms not supporting ratcheting.
   (@interface func (export "symmetric_state_ratchet")
     (param $handle $symmetric_state)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Return the length of an authentication tag.
@@ -556,8 +538,7 @@
   ;;; This function can be used by a guest to allocate the correct buffer size to copy a computed authentication tag.
   (@interface func (export "symmetric_tag_len")
     (param $symmetric_tag $symmetric_tag)
-    (result $error $crypto_errno)
-    (result $len $size)
+    (result $error (expected $size (error $crypto_errno)))
   )
 
   ;;; Copy an authentication tag into a guest-allocated buffer.
@@ -578,8 +559,7 @@
     (param $symmetric_tag $symmetric_tag)
     (param $buf (@witx pointer u8))
     (param $buf_len $size)
-    (result $error $crypto_errno)
-    (result $len $size)
+    (result $error (expected $size (error $crypto_errno)))
   )
 
   ;;; Verify that a computed authentication tag matches the expected value, in constant-time.
@@ -601,7 +581,7 @@
     (param $symmetric_tag $symmetric_tag)
     (param $expected_raw_tag_ptr (@witx const_pointer u8))
     (param $expected_raw_tag_len $size)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 
   ;;; Explicitly destroy an unused authentication tag.
@@ -611,6 +591,6 @@
   ;;; Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
   (@interface func (export "symmetric_tag_close")
     (param $symmetric_tag $symmetric_tag)
-    (result $error $crypto_errno)
+    (result $error (expected (error $crypto_errno)))
   )
 )

--- a/witx/wasi_ephemeral_crypto.md
+++ b/witx/wasi_ephemeral_crypto.md
@@ -1,12 +1,12 @@
 # Types
-## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: Enum(`u16`)
+## <a href="#crypto_errno" name="crypto_errno"></a> `crypto_errno`: `Variant`
 Error codes.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#crypto_errno.success" name="crypto_errno.success"></a> `success`
 Operation succeeded.
 
@@ -151,14 +151,14 @@ This error is returned when trying to build a key pair from a public key and a s
 - <a href="#crypto_errno.expired" name="crypto_errno.expired"></a> `expired`
 A managed key or secret expired and cannot be used any more.
 
-## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: Enum(`u16`)
+## <a href="#keypair_encoding" name="keypair_encoding"></a> `keypair_encoding`: `Variant`
 Encoding to use for importing or exporting a key pair.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#keypair_encoding.raw" name="keypair_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -171,14 +171,14 @@ PEM encoding.
 - <a href="#keypair_encoding.local" name="keypair_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: Enum(`u16`)
+## <a href="#publickey_encoding" name="publickey_encoding"></a> `publickey_encoding`: `Variant`
 Encoding to use for importing or exporting a public key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#publickey_encoding.raw" name="publickey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -197,14 +197,14 @@ Compressed SEC encoding.
 - <a href="#publickey_encoding.local" name="publickey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: Enum(`u16`)
+## <a href="#secretkey_encoding" name="secretkey_encoding"></a> `secretkey_encoding`: `Variant`
 Encoding to use for importing or exporting a secret key.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#secretkey_encoding.raw" name="secretkey_encoding.raw"></a> `raw`
 Raw bytes.
 
@@ -223,52 +223,49 @@ Compressed SEC encoding.
 - <a href="#secretkey_encoding.local" name="secretkey_encoding.local"></a> `local`
 Implementation-defined encoding.
 
-## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: Enum(`u16`)
+## <a href="#signature_encoding" name="signature_encoding"></a> `signature_encoding`: `Variant`
 Encoding to use for importing or exporting a signature.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#signature_encoding.raw" name="signature_encoding.raw"></a> `raw`
 Raw bytes.
 
 - <a href="#signature_encoding.der" name="signature_encoding.der"></a> `der`
 DER encoding.
 
-## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: Enum(`u16`)
+## <a href="#algorithm_type" name="algorithm_type"></a> `algorithm_type`: `Variant`
 An algorithm category.
 
 Size: 2
 
 Alignment: 2
 
-### Variants
+### Variant cases
 - <a href="#algorithm_type.signatures" name="algorithm_type.signatures"></a> `signatures`
 
 - <a href="#algorithm_type.symmetric" name="algorithm_type.symmetric"></a> `symmetric`
 
 - <a href="#algorithm_type.key_exchange" name="algorithm_type.key_exchange"></a> `key_exchange`
 
-## <a href="#version" name="version"></a> `version`: Int(`u64`)
+## <a href="#version" name="version"></a> `version`: `u64`
 Version of a managed key.
 
-A version can be an arbitrary `u64` integer, with the expection of some reserved values.
+A version can be an arbitrary [`u64`](#u64) integer, with the expection of some reserved values.
 
 Size: 8
 
 Alignment: 8
 
-### Consts
+### Constants
 - <a href="#version.unspecified" name="version.unspecified"></a> `unspecified`
-Key doesn't support versioning.
 
 - <a href="#version.latest" name="version.latest"></a> `latest`
-Use the latest version of a key.
 
 - <a href="#version.all" name="version.all"></a> `all`
-Perform an operation over all versions of a key.
 
 ## <a href="#size" name="size"></a> `size`: `usize`
 Size of a value.
@@ -284,7 +281,7 @@ Size: 8
 
 Alignment: 8
 
-## <a href="#array_output" name="array_output"></a> `array_output`
+## <a href="#array_output" name="array_output"></a> `array_output`: `Handle`
 Handle for functions returning output whose size may be large or not known in advance.
 
 An [`array_output`](#array_output) object contains a host-allocated byte array.
@@ -299,7 +296,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#options" name="options"></a> `options`
+## <a href="#options" name="options"></a> `options`: `Handle`
 A set of options.
 
 This type is used to set non-default parameters.
@@ -311,7 +308,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`
+## <a href="#secrets_manager" name="secrets_manager"></a> `secrets_manager`: `Handle`
 A handle to the optional secrets management facilities offered by a host.
 
 This is used to generate, retrieve and invalidate managed keys.
@@ -321,7 +318,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#keypair" name="keypair"></a> `keypair`
+## <a href="#keypair" name="keypair"></a> `keypair`: `Handle`
 A key pair.
 
 Size: 4
@@ -329,7 +326,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_state" name="signature_state"></a> `signature_state`
+## <a href="#signature_state" name="signature_state"></a> `signature_state`: `Handle`
 A state to absorb data to be signed.
 
 After a signature has been computed or verified, the state remains valid for further operations.
@@ -341,7 +338,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature" name="signature"></a> `signature`
+## <a href="#signature" name="signature"></a> `signature`: `Handle`
 A signature.
 
 Size: 4
@@ -349,7 +346,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#publickey" name="publickey"></a> `publickey`
+## <a href="#publickey" name="publickey"></a> `publickey`: `Handle`
 A public key, for key exchange and signature verification.
 
 Size: 4
@@ -357,7 +354,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#secretkey" name="secretkey"></a> `secretkey`
+## <a href="#secretkey" name="secretkey"></a> `secretkey`: `Handle`
 A secret key, for key exchange mechanisms.
 
 Size: 4
@@ -365,7 +362,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`
+## <a href="#signature_verification_state" name="signature_verification_state"></a> `signature_verification_state`: `Handle`
 A state to absorb signed data to be verified.
 
 Size: 4
@@ -373,7 +370,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`
+## <a href="#symmetric_state" name="symmetric_state"></a> `symmetric_state`: `Handle`
 A state to perform symmetric operations.
 
 The state is not reset nor invalidated after an option has been performed.
@@ -384,7 +381,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`
+## <a href="#symmetric_key" name="symmetric_key"></a> `symmetric_key`: `Handle`
 A symmetric key.
 
 The key can be imported from raw bytes, or can be a reference to a managed key.
@@ -396,7 +393,7 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`
+## <a href="#symmetric_tag" name="symmetric_tag"></a> `symmetric_tag`: `Handle`
 An authentication tag.
 
 This is an object returned by functions computing authentication tags.
@@ -412,19 +409,19 @@ Size: 4
 Alignment: 4
 
 ### Supertypes
-## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: Enum(`u8`)
+## <a href="#opt_options_u" name="opt_options_u"></a> `opt_options_u`: `Variant`
 Options index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_options_u.some" name="opt_options_u.some"></a> `some`
 
 - <a href="#opt_options_u.none" name="opt_options_u.none"></a> `none`
 
-## <a href="#opt_options" name="opt_options"></a> `opt_options`: Union
+## <a href="#opt_options" name="opt_options"></a> `opt_options`: `Variant`
 An optional options set.
 
 This union simulates an `Option<Options>` type to make the [`options`](#options) parameter of some functions optional.
@@ -433,30 +430,28 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_options.some" name="opt_options.some"></a> `some`: [`options`](#options)
 
 - <a href="#opt_options.none" name="opt_options.none"></a> `none`
 
-## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: Enum(`u8`)
+## <a href="#opt_symmetric_key_u" name="opt_symmetric_key_u"></a> `opt_symmetric_key_u`: `Variant`
 Symmetric key index, only required by the Interface Types translation layer.
 
 Size: 1
 
 Alignment: 1
 
-### Variants
+### Variant cases
 - <a href="#opt_symmetric_key_u.some" name="opt_symmetric_key_u.some"></a> `some`
 
 - <a href="#opt_symmetric_key_u.none" name="opt_symmetric_key_u.none"></a> `none`
 
-## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: Union
+## <a href="#opt_symmetric_key" name="opt_symmetric_key"></a> `opt_symmetric_key`: `Variant`
 An optional symmetric key.
 
 This union simulates an `Option<SymmetricKey>` type to make the [`symmetric_key`](#symmetric_key) parameter of some functions optional.
@@ -465,16 +460,20 @@ Size: 8
 
 Alignment: 4
 
-### Union Layout
+### Variant Layout
+- size: 8
+- align: 4
 - tag_size: 1
-- tag_align: 1
-- contents_offset: 4
-- contents_size: 4
-- contents_align: 4
-### Union variants
+### Variant cases
 - <a href="#opt_symmetric_key.some" name="opt_symmetric_key.some"></a> `some`: [`symmetric_key`](#symmetric_key)
 
 - <a href="#opt_symmetric_key.none" name="opt_symmetric_key.none"></a> `none`
+
+## <a href="#u64" name="u64"></a> `u64`: `u64`
+
+Size: 8
+
+Alignment: 8
 
 ## <a href="#signature_keypair" name="signature_keypair"></a> `signature_keypair`: [`keypair`](#keypair)
 `$signature_keypair` is just an alias for `$keypair`
@@ -538,7 +537,7 @@ Alignment: 4
 
 ---
 
-#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> (crypto_errno, options)`
+#### <a href="#options_open" name="options_open"></a> `options_open(algorithm_type: algorithm_type) -> Result<options, crypto_errno>`
 Create a new object to set non-default options.
 
 Example usage:
@@ -555,14 +554,21 @@ options_close(options_handle)?;
 - <a href="#options_open.algorithm_type" name="options_open.algorithm_type"></a> `algorithm_type`: [`algorithm_type`](#algorithm_type)
 
 ##### Results
-- <a href="#options_open.error" name="options_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_open.error" name="options_open.error"></a> `error`: `Result<options, crypto_errno>`
 
-- <a href="#options_open.handle" name="options_open.handle"></a> `handle`: [`options`](#options)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_open.error.ok" name="options_open.error.ok"></a> `ok`: [`options`](#options)
+
+- <a href="#options_open.error.err" name="options_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> crypto_errno`
+#### <a href="#options_close" name="options_close"></a> `options_close(handle: options) -> Result<(), crypto_errno>`
 Destroy an options object.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -571,12 +577,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#options_close.handle" name="options_close.handle"></a> `handle`: [`options`](#options)
 
 ##### Results
-- <a href="#options_close.error" name="options_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_close.error" name="options_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_close.error.ok" name="options_close.error.ok"></a> `ok`
+
+- <a href="#options_close.error.err" name="options_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> crypto_errno`
+#### <a href="#options_set" name="options_set"></a> `options_set(handle: options, name: string, value: ConstPointer<u8>, value_len: size) -> Result<(), crypto_errno>`
 Set or update an option.
 
 This is used to set algorithm-specific parameters, but also to provide credentials for the secrets management facilities, if required.
@@ -593,12 +608,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set.value_len" name="options_set.value_len"></a> `value_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set.error" name="options_set.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set.error" name="options_set.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set.error.ok" name="options_set.error.ok"></a> `ok`
+
+- <a href="#options_set.error.err" name="options_set.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> crypto_errno`
+#### <a href="#options_set_u64" name="options_set_u64"></a> `options_set_u64(handle: options, name: string, value: u64) -> Result<(), crypto_errno>`
 Set or update an integer option.
 
 This is used to set algorithm-specific parameters.
@@ -613,12 +637,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_u64.value" name="options_set_u64.value"></a> `value`: `u64`
 
 ##### Results
-- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_u64.error" name="options_set_u64.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_u64.error.ok" name="options_set_u64.error.ok"></a> `ok`
+
+- <a href="#options_set_u64.error.err" name="options_set_u64.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> crypto_errno`
+#### <a href="#options_set_guest_buffer" name="options_set_guest_buffer"></a> `options_set_guest_buffer(handle: options, name: string, buffer: Pointer<u8>, buffer_len: size) -> Result<(), crypto_errno>`
 Set or update a guest-allocated memory that the host can use or return data into.
 
 This is for example used to set the scratch buffer required by memory-hard functions.
@@ -635,12 +668,21 @@ This function may return `unsupported_option` if an option that doesn't exist fo
 - <a href="#options_set_guest_buffer.buffer_len" name="options_set_guest_buffer.buffer_len"></a> `buffer_len`: [`size`](#size)
 
 ##### Results
-- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#options_set_guest_buffer.error" name="options_set_guest_buffer.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#options_set_guest_buffer.error.ok" name="options_set_guest_buffer.error.ok"></a> `ok`
+
+- <a href="#options_set_guest_buffer.error.err" name="options_set_guest_buffer.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> (crypto_errno, size)`
+#### <a href="#array_output_len" name="array_output_len"></a> `array_output_len(array_output: array_output) -> Result<size, crypto_errno>`
 Return the length of an [`array_output`](#array_output) object.
 
 This allows a guest to allocate a buffer of the correct size in order to copy the output of a function returning this object type.
@@ -649,14 +691,21 @@ This allows a guest to allocate a buffer of the correct size in order to copy th
 - <a href="#array_output_len.array_output" name="array_output_len.array_output"></a> `array_output`: [`array_output`](#array_output)
 
 ##### Results
-- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_len.error" name="array_output_len.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_len.len" name="array_output_len.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_len.error.ok" name="array_output_len.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_len.error.err" name="array_output_len.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> (crypto_errno, size)`
+#### <a href="#array_output_pull" name="array_output_pull"></a> `array_output_pull(array_output: array_output, buf: Pointer<u8>, buf_len: size) -> Result<size, crypto_errno>`
 Copy the content of an [`array_output`](#array_output) object into an application-allocated buffer.
 
 Multiple calls to that function can be made in order to consume the data in a streaming fashion, if necessary.
@@ -681,14 +730,21 @@ array_output_pull(output_handle, &mut out)?;
 - <a href="#array_output_pull.buf_len" name="array_output_pull.buf_len"></a> `buf_len`: [`size`](#size)
 
 ##### Results
-- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#array_output_pull.error" name="array_output_pull.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#array_output_pull.len" name="array_output_pull.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#array_output_pull.error.ok" name="array_output_pull.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#array_output_pull.error.err" name="array_output_pull.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> (crypto_errno, secrets_manager)`
+#### <a href="#secrets_manager_open" name="secrets_manager_open"></a> `secrets_manager_open(options: opt_options) -> Result<secrets_manager, crypto_errno>`
 __(optional)__
 Create a context to use a secrets manager.
 
@@ -701,14 +757,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_open.options" name="secrets_manager_open.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_open.error" name="secrets_manager_open.error"></a> `error`: `Result<secrets_manager, crypto_errno>`
 
-- <a href="#secrets_manager_open.handle" name="secrets_manager_open.handle"></a> `handle`: [`secrets_manager`](#secrets_manager)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_open.error.ok" name="secrets_manager_open.error.ok"></a> `ok`: [`secrets_manager`](#secrets_manager)
+
+- <a href="#secrets_manager_open.error.err" name="secrets_manager_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> crypto_errno`
+#### <a href="#secrets_manager_close" name="secrets_manager_close"></a> `secrets_manager_close(secrets_manager: secrets_manager) -> Result<(), crypto_errno>`
 __(optional)__
 Destroy a secrets manager context.
 
@@ -719,12 +782,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_close.secrets_manager" name="secrets_manager_close.secrets_manager"></a> `secrets_manager`: [`secrets_manager`](#secrets_manager)
 
 ##### Results
-- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_close.error" name="secrets_manager_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_close.error.ok" name="secrets_manager_close.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_close.error.err" name="secrets_manager_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> crypto_errno`
+#### <a href="#secrets_manager_invalidate" name="secrets_manager_invalidate"></a> `secrets_manager_invalidate(secrets_manager: secrets_manager, key_id: ConstPointer<u8>, key_id_len: size, key_version: version) -> Result<(), crypto_errno>`
 __(optional)__
 Invalidate a managed key or key pair given an identifier and a version.
 
@@ -746,7 +818,16 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#secrets_manager_invalidate.key_version" name="secrets_manager_invalidate.key_version"></a> `key_version`: [`version`](#version)
 
 ##### Results
-- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secrets_manager_invalidate.error" name="secrets_manager_invalidate.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secrets_manager_invalidate.error.ok" name="secrets_manager_invalidate.error.ok"></a> `ok`
+
+- <a href="#secrets_manager_invalidate.error.err" name="secrets_manager_invalidate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 ## <a href="#wasi_ephemeral_crypto_asymmetric_common" name="wasi_ephemeral_crypto_asymmetric_common"></a> wasi_ephemeral_crypto_asymmetric_common
 ### Imports
@@ -755,7 +836,7 @@ This is an optional import, meaning that the function may not even exist.
 
 ---
 
-#### <a href="#keypair_generate" name="keypair_generate"></a> `keypair_generate(algorithm_type: algorithm_type, algorithm: string, options: opt_options) -> (crypto_errno, keypair)`
+#### <a href="#keypair_generate" name="keypair_generate"></a> `keypair_generate(algorithm_type: algorithm_type, algorithm: string, options: opt_options) -> Result<keypair, crypto_errno>`
 Generate a new key pair.
 
 Internally, a key pair stores the supplied algorithm and optional parameters.
@@ -783,14 +864,21 @@ let kp_handle = ctx.keypair_generate(AlgorithmType::Signatures, "RSA_PKCS1_2048_
 - <a href="#keypair_generate.options" name="keypair_generate.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#keypair_generate.error" name="keypair_generate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_generate.error" name="keypair_generate.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_generate.handle" name="keypair_generate.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_generate.error.ok" name="keypair_generate.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_generate.error.err" name="keypair_generate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_import" name="keypair_import"></a> `keypair_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: keypair_encoding) -> (crypto_errno, keypair)`
+#### <a href="#keypair_import" name="keypair_import"></a> `keypair_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: keypair_encoding) -> Result<keypair, crypto_errno>`
 Import a key pair.
 
 This function creates a [`keypair`](#keypair) object from existing material.
@@ -817,14 +905,21 @@ let kp_handle = ctx.keypair_import(AlgorithmType::Signatures, "RSA_PKCS1_2048_SH
 - <a href="#keypair_import.encoding" name="keypair_import.encoding"></a> `encoding`: [`keypair_encoding`](#keypair_encoding)
 
 ##### Results
-- <a href="#keypair_import.error" name="keypair_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_import.error" name="keypair_import.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_import.handle" name="keypair_import.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_import.error.ok" name="keypair_import.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_import.error.err" name="keypair_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_generate_managed" name="keypair_generate_managed"></a> `keypair_generate_managed(secrets_manager: secrets_manager, algorithm_type: algorithm_type, algorithm: string, options: opt_options) -> (crypto_errno, keypair)`
+#### <a href="#keypair_generate_managed" name="keypair_generate_managed"></a> `keypair_generate_managed(secrets_manager: secrets_manager, algorithm_type: algorithm_type, algorithm: string, options: opt_options) -> Result<keypair, crypto_errno>`
 __(optional)__
 Generate a new managed key pair.
 
@@ -849,14 +944,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#keypair_generate_managed.options" name="keypair_generate_managed.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#keypair_generate_managed.error" name="keypair_generate_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_generate_managed.error" name="keypair_generate_managed.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_generate_managed.handle" name="keypair_generate_managed.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_generate_managed.error.ok" name="keypair_generate_managed.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_generate_managed.error.err" name="keypair_generate_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_store_managed" name="keypair_store_managed"></a> `keypair_store_managed(secrets_manager: secrets_manager, kp: keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> crypto_errno`
+#### <a href="#keypair_store_managed" name="keypair_store_managed"></a> `keypair_store_managed(secrets_manager: secrets_manager, kp: keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> Result<(), crypto_errno>`
 __(optional)__
 Store a key pair into the secrets manager.
 
@@ -875,12 +977,21 @@ The function returns `overflow` if the supplied buffer is too small.
 - <a href="#keypair_store_managed.kp_id_max_len" name="keypair_store_managed.kp_id_max_len"></a> `kp_id_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#keypair_store_managed.error" name="keypair_store_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_store_managed.error" name="keypair_store_managed.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_store_managed.error.ok" name="keypair_store_managed.error.ok"></a> `ok`
+
+- <a href="#keypair_store_managed.error.err" name="keypair_store_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_replace_managed" name="keypair_replace_managed"></a> `keypair_replace_managed(secrets_manager: secrets_manager, kp_old: keypair, kp_new: keypair) -> (crypto_errno, version)`
+#### <a href="#keypair_replace_managed" name="keypair_replace_managed"></a> `keypair_replace_managed(secrets_manager: secrets_manager, kp_old: keypair, kp_new: keypair) -> Result<version, crypto_errno>`
 __(optional)__
 Replace a managed key pair.
 
@@ -911,14 +1022,21 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#keypair_replace_managed.kp_new" name="keypair_replace_managed.kp_new"></a> `kp_new`: [`keypair`](#keypair)
 
 ##### Results
-- <a href="#keypair_replace_managed.error" name="keypair_replace_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_replace_managed.error" name="keypair_replace_managed.error"></a> `error`: `Result<version, crypto_errno>`
 
-- <a href="#keypair_replace_managed.version" name="keypair_replace_managed.version"></a> `version`: [`version`](#version)
+###### Variant Layout
+- size: 16
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_replace_managed.error.ok" name="keypair_replace_managed.error.ok"></a> `ok`: [`version`](#version)
+
+- <a href="#keypair_replace_managed.error.err" name="keypair_replace_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_id" name="keypair_id"></a> `keypair_id(kp: keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> (crypto_errno, size, version)`
+#### <a href="#keypair_id" name="keypair_id"></a> `keypair_id(kp: keypair, kp_id: Pointer<u8>, kp_id_max_len: size) -> Result<(size, version), crypto_errno>`
 __(optional)__
 Return the key pair identifier and version of a managed key pair.
 
@@ -934,16 +1052,30 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#keypair_id.kp_id_max_len" name="keypair_id.kp_id_max_len"></a> `kp_id_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#keypair_id.error" name="keypair_id.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_id.error" name="keypair_id.error"></a> `error`: `Result<(size, version), crypto_errno>`
 
-- <a href="#keypair_id.kp_id_len" name="keypair_id.kp_id_len"></a> `kp_id_len`: [`size`](#size)
+###### Variant Layout
+- size: 24
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_id.error.ok" name="keypair_id.error.ok"></a> `ok`: `(size, version)`
 
-- <a href="#keypair_id.version" name="keypair_id.version"></a> `version`: [`version`](#version)
+####### Record members
+- <a href="#keypair_id.error.ok.0" name="keypair_id.error.ok.0"></a> `0`: [`size`](#size)
+
+Offset: 0
+
+- <a href="#keypair_id.error.ok.1" name="keypair_id.error.ok.1"></a> `1`: [`version`](#version)
+
+Offset: 8
+
+- <a href="#keypair_id.error.err" name="keypair_id.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_from_id" name="keypair_from_id"></a> `keypair_from_id(secrets_manager: secrets_manager, kp_id: ConstPointer<u8>, kp_id_len: size, kp_version: version) -> (crypto_errno, keypair)`
+#### <a href="#keypair_from_id" name="keypair_from_id"></a> `keypair_from_id(secrets_manager: secrets_manager, kp_id: ConstPointer<u8>, kp_id_len: size, kp_version: version) -> Result<keypair, crypto_errno>`
 __(optional)__
 Return a managed key pair from a key identifier.
 
@@ -963,14 +1095,21 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#keypair_from_id.kp_version" name="keypair_from_id.kp_version"></a> `kp_version`: [`version`](#version)
 
 ##### Results
-- <a href="#keypair_from_id.error" name="keypair_from_id.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_from_id.error" name="keypair_from_id.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_from_id.handle" name="keypair_from_id.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_from_id.error.ok" name="keypair_from_id.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_from_id.error.err" name="keypair_from_id.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_from_pk_and_sk" name="keypair_from_pk_and_sk"></a> `keypair_from_pk_and_sk(publickey: publickey, secretkey: secretkey) -> (crypto_errno, keypair)`
+#### <a href="#keypair_from_pk_and_sk" name="keypair_from_pk_and_sk"></a> `keypair_from_pk_and_sk(publickey: publickey, secretkey: secretkey) -> Result<keypair, crypto_errno>`
 Create a key pair from a public key and a secret key.
 
 ##### Params
@@ -979,14 +1118,21 @@ Create a key pair from a public key and a secret key.
 - <a href="#keypair_from_pk_and_sk.secretkey" name="keypair_from_pk_and_sk.secretkey"></a> `secretkey`: [`secretkey`](#secretkey)
 
 ##### Results
-- <a href="#keypair_from_pk_and_sk.error" name="keypair_from_pk_and_sk.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_from_pk_and_sk.error" name="keypair_from_pk_and_sk.error"></a> `error`: `Result<keypair, crypto_errno>`
 
-- <a href="#keypair_from_pk_and_sk.handle" name="keypair_from_pk_and_sk.handle"></a> `handle`: [`keypair`](#keypair)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_from_pk_and_sk.error.ok" name="keypair_from_pk_and_sk.error.ok"></a> `ok`: [`keypair`](#keypair)
+
+- <a href="#keypair_from_pk_and_sk.error.err" name="keypair_from_pk_and_sk.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_export" name="keypair_export"></a> `keypair_export(kp: keypair, encoding: keypair_encoding) -> (crypto_errno, array_output)`
+#### <a href="#keypair_export" name="keypair_export"></a> `keypair_export(kp: keypair, encoding: keypair_encoding) -> Result<array_output, crypto_errno>`
 Export a key pair as the given encoding format.
 
 May return `prohibited_operation` if this operation is denied or `unsupported_encoding` if the encoding is not supported.
@@ -997,42 +1143,63 @@ May return `prohibited_operation` if this operation is denied or `unsupported_en
 - <a href="#keypair_export.encoding" name="keypair_export.encoding"></a> `encoding`: [`keypair_encoding`](#keypair_encoding)
 
 ##### Results
-- <a href="#keypair_export.error" name="keypair_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_export.error" name="keypair_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#keypair_export.encoded" name="keypair_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_export.error.ok" name="keypair_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#keypair_export.error.err" name="keypair_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_publickey" name="keypair_publickey"></a> `keypair_publickey(kp: keypair) -> (crypto_errno, publickey)`
+#### <a href="#keypair_publickey" name="keypair_publickey"></a> `keypair_publickey(kp: keypair) -> Result<publickey, crypto_errno>`
 Get the public key of a key pair.
 
 ##### Params
 - <a href="#keypair_publickey.kp" name="keypair_publickey.kp"></a> `kp`: [`keypair`](#keypair)
 
 ##### Results
-- <a href="#keypair_publickey.error" name="keypair_publickey.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_publickey.error" name="keypair_publickey.error"></a> `error`: `Result<publickey, crypto_errno>`
 
-- <a href="#keypair_publickey.pk" name="keypair_publickey.pk"></a> `pk`: [`publickey`](#publickey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_publickey.error.ok" name="keypair_publickey.error.ok"></a> `ok`: [`publickey`](#publickey)
+
+- <a href="#keypair_publickey.error.err" name="keypair_publickey.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_secretkey" name="keypair_secretkey"></a> `keypair_secretkey(kp: keypair) -> (crypto_errno, secretkey)`
+#### <a href="#keypair_secretkey" name="keypair_secretkey"></a> `keypair_secretkey(kp: keypair) -> Result<secretkey, crypto_errno>`
 Get the secret key of a key pair.
 
 ##### Params
 - <a href="#keypair_secretkey.kp" name="keypair_secretkey.kp"></a> `kp`: [`keypair`](#keypair)
 
 ##### Results
-- <a href="#keypair_secretkey.error" name="keypair_secretkey.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_secretkey.error" name="keypair_secretkey.error"></a> `error`: `Result<secretkey, crypto_errno>`
 
-- <a href="#keypair_secretkey.sk" name="keypair_secretkey.sk"></a> `sk`: [`secretkey`](#secretkey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_secretkey.error.ok" name="keypair_secretkey.error.ok"></a> `ok`: [`secretkey`](#secretkey)
+
+- <a href="#keypair_secretkey.error.err" name="keypair_secretkey.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#keypair_close" name="keypair_close"></a> `keypair_close(kp: keypair) -> crypto_errno`
+#### <a href="#keypair_close" name="keypair_close"></a> `keypair_close(kp: keypair) -> Result<(), crypto_errno>`
 Destroy a key pair.
 
 The host will automatically wipe traces of the secret key from memory.
@@ -1043,12 +1210,21 @@ If this is a managed key, the key will not be removed from persistent storage, a
 - <a href="#keypair_close.kp" name="keypair_close.kp"></a> `kp`: [`keypair`](#keypair)
 
 ##### Results
-- <a href="#keypair_close.error" name="keypair_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#keypair_close.error" name="keypair_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#keypair_close.error.ok" name="keypair_close.error.ok"></a> `ok`
+
+- <a href="#keypair_close.error.err" name="keypair_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_import" name="publickey_import"></a> `publickey_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: publickey_encoding) -> (crypto_errno, publickey)`
+#### <a href="#publickey_import" name="publickey_import"></a> `publickey_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: publickey_encoding) -> Result<publickey, crypto_errno>`
 Import a public key.
 
 The function may return `unsupported_encoding` if importing from the given format is not implemented or incompatible with the key type.
@@ -1075,14 +1251,21 @@ let pk_handle = ctx.publickey_import(AlgorithmType::Signatures, encoded, PublicK
 - <a href="#publickey_import.encoding" name="publickey_import.encoding"></a> `encoding`: [`publickey_encoding`](#publickey_encoding)
 
 ##### Results
-- <a href="#publickey_import.error" name="publickey_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_import.error" name="publickey_import.error"></a> `error`: `Result<publickey, crypto_errno>`
 
-- <a href="#publickey_import.pk" name="publickey_import.pk"></a> `pk`: [`publickey`](#publickey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_import.error.ok" name="publickey_import.error.ok"></a> `ok`: [`publickey`](#publickey)
+
+- <a href="#publickey_import.error.err" name="publickey_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_export" name="publickey_export"></a> `publickey_export(pk: publickey, encoding: publickey_encoding) -> (crypto_errno, array_output)`
+#### <a href="#publickey_export" name="publickey_export"></a> `publickey_export(pk: publickey, encoding: publickey_encoding) -> Result<array_output, crypto_errno>`
 Export a public key as the given encoding format.
 
 May return `unsupported_encoding` if the encoding is not supported.
@@ -1093,14 +1276,21 @@ May return `unsupported_encoding` if the encoding is not supported.
 - <a href="#publickey_export.encoding" name="publickey_export.encoding"></a> `encoding`: [`publickey_encoding`](#publickey_encoding)
 
 ##### Results
-- <a href="#publickey_export.error" name="publickey_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_export.error" name="publickey_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#publickey_export.encoded" name="publickey_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_export.error.ok" name="publickey_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#publickey_export.error.err" name="publickey_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_verify" name="publickey_verify"></a> `publickey_verify(pk: publickey) -> crypto_errno`
+#### <a href="#publickey_verify" name="publickey_verify"></a> `publickey_verify(pk: publickey) -> Result<(), crypto_errno>`
 Check that a public key is valid and in canonical form.
 
 This function may perform stricter checks than those made during importation at the expense of additional CPU cycles.
@@ -1111,26 +1301,42 @@ The function returns `invalid_key` if the public key didn't pass the checks.
 - <a href="#publickey_verify.pk" name="publickey_verify.pk"></a> `pk`: [`publickey`](#publickey)
 
 ##### Results
-- <a href="#publickey_verify.error" name="publickey_verify.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_verify.error" name="publickey_verify.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_verify.error.ok" name="publickey_verify.error.ok"></a> `ok`
+
+- <a href="#publickey_verify.error.err" name="publickey_verify.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_from_secretkey" name="publickey_from_secretkey"></a> `publickey_from_secretkey(sk: secretkey) -> (crypto_errno, publickey)`
+#### <a href="#publickey_from_secretkey" name="publickey_from_secretkey"></a> `publickey_from_secretkey(sk: secretkey) -> Result<publickey, crypto_errno>`
 Compute the public key for a secret key.
 
 ##### Params
 - <a href="#publickey_from_secretkey.sk" name="publickey_from_secretkey.sk"></a> `sk`: [`secretkey`](#secretkey)
 
 ##### Results
-- <a href="#publickey_from_secretkey.error" name="publickey_from_secretkey.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_from_secretkey.error" name="publickey_from_secretkey.error"></a> `error`: `Result<publickey, crypto_errno>`
 
-- <a href="#publickey_from_secretkey.pk" name="publickey_from_secretkey.pk"></a> `pk`: [`publickey`](#publickey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_from_secretkey.error.ok" name="publickey_from_secretkey.error.ok"></a> `ok`: [`publickey`](#publickey)
+
+- <a href="#publickey_from_secretkey.error.err" name="publickey_from_secretkey.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#publickey_close" name="publickey_close"></a> `publickey_close(pk: publickey) -> crypto_errno`
+#### <a href="#publickey_close" name="publickey_close"></a> `publickey_close(pk: publickey) -> Result<(), crypto_errno>`
 Destroy a public key.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1139,12 +1345,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#publickey_close.pk" name="publickey_close.pk"></a> `pk`: [`publickey`](#publickey)
 
 ##### Results
-- <a href="#publickey_close.error" name="publickey_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#publickey_close.error" name="publickey_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#publickey_close.error.ok" name="publickey_close.error.ok"></a> `ok`
+
+- <a href="#publickey_close.error.err" name="publickey_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secretkey_import" name="secretkey_import"></a> `secretkey_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: secretkey_encoding) -> (crypto_errno, secretkey)`
+#### <a href="#secretkey_import" name="secretkey_import"></a> `secretkey_import(algorithm_type: algorithm_type, algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: secretkey_encoding) -> Result<secretkey, crypto_errno>`
 Import a secret key.
 
 The function may return `unsupported_encoding` if importing from the given format is not implemented or incompatible with the key type.
@@ -1171,14 +1386,21 @@ let pk_handle = ctx.secretkey_import(AlgorithmType::KX, encoded, SecretKeyEncodi
 - <a href="#secretkey_import.encoding" name="secretkey_import.encoding"></a> `encoding`: [`secretkey_encoding`](#secretkey_encoding)
 
 ##### Results
-- <a href="#secretkey_import.error" name="secretkey_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secretkey_import.error" name="secretkey_import.error"></a> `error`: `Result<secretkey, crypto_errno>`
 
-- <a href="#secretkey_import.sk" name="secretkey_import.sk"></a> `sk`: [`secretkey`](#secretkey)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secretkey_import.error.ok" name="secretkey_import.error.ok"></a> `ok`: [`secretkey`](#secretkey)
+
+- <a href="#secretkey_import.error.err" name="secretkey_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secretkey_export" name="secretkey_export"></a> `secretkey_export(sk: secretkey, encoding: secretkey_encoding) -> (crypto_errno, array_output)`
+#### <a href="#secretkey_export" name="secretkey_export"></a> `secretkey_export(sk: secretkey, encoding: secretkey_encoding) -> Result<array_output, crypto_errno>`
 Export a secret key as the given encoding format.
 
 May return `unsupported_encoding` if the encoding is not supported.
@@ -1189,14 +1411,21 @@ May return `unsupported_encoding` if the encoding is not supported.
 - <a href="#secretkey_export.encoding" name="secretkey_export.encoding"></a> `encoding`: [`secretkey_encoding`](#secretkey_encoding)
 
 ##### Results
-- <a href="#secretkey_export.error" name="secretkey_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secretkey_export.error" name="secretkey_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#secretkey_export.encoded" name="secretkey_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secretkey_export.error.ok" name="secretkey_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#secretkey_export.error.err" name="secretkey_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#secretkey_close" name="secretkey_close"></a> `secretkey_close(sk: secretkey) -> crypto_errno`
+#### <a href="#secretkey_close" name="secretkey_close"></a> `secretkey_close(sk: secretkey) -> Result<(), crypto_errno>`
 Destroy a secret key.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1205,7 +1434,16 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#secretkey_close.sk" name="secretkey_close.sk"></a> `sk`: [`secretkey`](#secretkey)
 
 ##### Results
-- <a href="#secretkey_close.error" name="secretkey_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#secretkey_close.error" name="secretkey_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#secretkey_close.error.ok" name="secretkey_close.error.ok"></a> `ok`
+
+- <a href="#secretkey_close.error.err" name="secretkey_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 ## <a href="#wasi_ephemeral_crypto_signatures" name="wasi_ephemeral_crypto_signatures"></a> wasi_ephemeral_crypto_signatures
 ### Imports
@@ -1214,7 +1452,7 @@ Objects are reference counted. It is safe to close an object immediately after t
 
 ---
 
-#### <a href="#signature_export" name="signature_export"></a> `signature_export(signature: signature, encoding: signature_encoding) -> (crypto_errno, array_output)`
+#### <a href="#signature_export" name="signature_export"></a> `signature_export(signature: signature, encoding: signature_encoding) -> Result<array_output, crypto_errno>`
 Export a signature.
 
 This function exports a signature object using the specified encoding.
@@ -1227,14 +1465,21 @@ May return `unsupported_encoding` if the signature cannot be encoded into the gi
 - <a href="#signature_export.encoding" name="signature_export.encoding"></a> `encoding`: [`signature_encoding`](#signature_encoding)
 
 ##### Results
-- <a href="#signature_export.error" name="signature_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_export.error" name="signature_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#signature_export.encoded" name="signature_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_export.error.ok" name="signature_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#signature_export.error.err" name="signature_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_import" name="signature_import"></a> `signature_import(algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: signature_encoding) -> (crypto_errno, signature)`
+#### <a href="#signature_import" name="signature_import"></a> `signature_import(algorithm: string, encoded: ConstPointer<u8>, encoded_len: size, encoding: signature_encoding) -> Result<signature, crypto_errno>`
 Create a signature object.
 
 This object can be used along with a public key to verify an existing signature.
@@ -1259,14 +1504,21 @@ let signature_handle = ctx.signature_import("ECDSA_P256_SHA256", SignatureEncodi
 - <a href="#signature_import.encoding" name="signature_import.encoding"></a> `encoding`: [`signature_encoding`](#signature_encoding)
 
 ##### Results
-- <a href="#signature_import.error" name="signature_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_import.error" name="signature_import.error"></a> `error`: `Result<signature, crypto_errno>`
 
-- <a href="#signature_import.signature" name="signature_import.signature"></a> `signature`: [`signature`](#signature)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_import.error.ok" name="signature_import.error.ok"></a> `ok`: [`signature`](#signature)
+
+- <a href="#signature_import.error.err" name="signature_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_state_open" name="signature_state_open"></a> `signature_state_open(kp: signature_keypair) -> (crypto_errno, signature_state)`
+#### <a href="#signature_state_open" name="signature_state_open"></a> `signature_state_open(kp: signature_keypair) -> Result<signature_state, crypto_errno>`
 Create a new state to collect data to compute a signature on.
 
 This function allows data to be signed to be supplied in a streaming fashion.
@@ -1288,14 +1540,21 @@ let raw_sig = ctx.signature_export(sig_handle, SignatureEncoding::Raw)?;
 - <a href="#signature_state_open.kp" name="signature_state_open.kp"></a> `kp`: [`signature_keypair`](#signature_keypair)
 
 ##### Results
-- <a href="#signature_state_open.error" name="signature_state_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_state_open.error" name="signature_state_open.error"></a> `error`: `Result<signature_state, crypto_errno>`
 
-- <a href="#signature_state_open.state" name="signature_state_open.state"></a> `state`: [`signature_state`](#signature_state)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_state_open.error.ok" name="signature_state_open.error.ok"></a> `ok`: [`signature_state`](#signature_state)
+
+- <a href="#signature_state_open.error.err" name="signature_state_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_state_update" name="signature_state_update"></a> `signature_state_update(state: signature_state, input: ConstPointer<u8>, input_len: size) -> crypto_errno`
+#### <a href="#signature_state_update" name="signature_state_update"></a> `signature_state_update(state: signature_state, input: ConstPointer<u8>, input_len: size) -> Result<(), crypto_errno>`
 Absorb data into the signature state.
 
 This function may return `unsupported_feature` is the selected algorithm doesn't support incremental updates.
@@ -1308,12 +1567,21 @@ This function may return `unsupported_feature` is the selected algorithm doesn't
 - <a href="#signature_state_update.input_len" name="signature_state_update.input_len"></a> `input_len`: [`size`](#size)
 
 ##### Results
-- <a href="#signature_state_update.error" name="signature_state_update.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_state_update.error" name="signature_state_update.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_state_update.error.ok" name="signature_state_update.error.ok"></a> `ok`
+
+- <a href="#signature_state_update.error.err" name="signature_state_update.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_state_sign" name="signature_state_sign"></a> `signature_state_sign(state: signature_state) -> (crypto_errno, array_output)`
+#### <a href="#signature_state_sign" name="signature_state_sign"></a> `signature_state_sign(state: signature_state) -> Result<array_output, crypto_errno>`
 Compute a signature for all the data collected up to that point.
 
 The function can be called multiple times for incremental signing.
@@ -1322,14 +1590,21 @@ The function can be called multiple times for incremental signing.
 - <a href="#signature_state_sign.state" name="signature_state_sign.state"></a> `state`: [`signature_state`](#signature_state)
 
 ##### Results
-- <a href="#signature_state_sign.error" name="signature_state_sign.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_state_sign.error" name="signature_state_sign.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#signature_state_sign.signature" name="signature_state_sign.signature"></a> `signature`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_state_sign.error.ok" name="signature_state_sign.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#signature_state_sign.error.err" name="signature_state_sign.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_state_close" name="signature_state_close"></a> `signature_state_close(state: signature_state) -> crypto_errno`
+#### <a href="#signature_state_close" name="signature_state_close"></a> `signature_state_close(state: signature_state) -> Result<(), crypto_errno>`
 Destroy a signature state.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1340,12 +1615,21 @@ Note that closing a signature state doesn't close or invalidate the key pair obj
 - <a href="#signature_state_close.state" name="signature_state_close.state"></a> `state`: [`signature_state`](#signature_state)
 
 ##### Results
-- <a href="#signature_state_close.error" name="signature_state_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_state_close.error" name="signature_state_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_state_close.error.ok" name="signature_state_close.error.ok"></a> `ok`
+
+- <a href="#signature_state_close.error.err" name="signature_state_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_verification_state_open" name="signature_verification_state_open"></a> `signature_verification_state_open(kp: signature_publickey) -> (crypto_errno, signature_verification_state)`
+#### <a href="#signature_verification_state_open" name="signature_verification_state_open"></a> `signature_verification_state_open(kp: signature_publickey) -> Result<signature_verification_state, crypto_errno>`
 Create a new state to collect data to verify a signature on.
 
 This is the verification counterpart of [`signature_state`](#signature_state).
@@ -1366,14 +1650,21 @@ ctx.signature_verification_state_verify(signature_handle)?;
 - <a href="#signature_verification_state_open.kp" name="signature_verification_state_open.kp"></a> `kp`: [`signature_publickey`](#signature_publickey)
 
 ##### Results
-- <a href="#signature_verification_state_open.error" name="signature_verification_state_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_verification_state_open.error" name="signature_verification_state_open.error"></a> `error`: `Result<signature_verification_state, crypto_errno>`
 
-- <a href="#signature_verification_state_open.state" name="signature_verification_state_open.state"></a> `state`: [`signature_verification_state`](#signature_verification_state)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_verification_state_open.error.ok" name="signature_verification_state_open.error.ok"></a> `ok`: [`signature_verification_state`](#signature_verification_state)
+
+- <a href="#signature_verification_state_open.error.err" name="signature_verification_state_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_verification_state_update" name="signature_verification_state_update"></a> `signature_verification_state_update(state: signature_verification_state, input: ConstPointer<u8>, input_len: size) -> crypto_errno`
+#### <a href="#signature_verification_state_update" name="signature_verification_state_update"></a> `signature_verification_state_update(state: signature_verification_state, input: ConstPointer<u8>, input_len: size) -> Result<(), crypto_errno>`
 Absorb data into the signature verification state.
 
 This function may return `unsupported_feature` is the selected algorithm doesn't support incremental updates.
@@ -1386,12 +1677,21 @@ This function may return `unsupported_feature` is the selected algorithm doesn't
 - <a href="#signature_verification_state_update.input_len" name="signature_verification_state_update.input_len"></a> `input_len`: [`size`](#size)
 
 ##### Results
-- <a href="#signature_verification_state_update.error" name="signature_verification_state_update.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_verification_state_update.error" name="signature_verification_state_update.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_verification_state_update.error.ok" name="signature_verification_state_update.error.ok"></a> `ok`
+
+- <a href="#signature_verification_state_update.error.err" name="signature_verification_state_update.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_verification_state_verify" name="signature_verification_state_verify"></a> `signature_verification_state_verify(state: signature_verification_state, signature: signature) -> crypto_errno`
+#### <a href="#signature_verification_state_verify" name="signature_verification_state_verify"></a> `signature_verification_state_verify(state: signature_verification_state, signature: signature) -> Result<(), crypto_errno>`
 Check that the given signature is verifies for the data collected up to that point point.
 
 The state is not closed and can absorb more data to allow for incremental verification.
@@ -1404,12 +1704,21 @@ The function returns `invalid_signature` if the signature doesn't appear to be v
 - <a href="#signature_verification_state_verify.signature" name="signature_verification_state_verify.signature"></a> `signature`: [`signature`](#signature)
 
 ##### Results
-- <a href="#signature_verification_state_verify.error" name="signature_verification_state_verify.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_verification_state_verify.error" name="signature_verification_state_verify.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_verification_state_verify.error.ok" name="signature_verification_state_verify.error.ok"></a> `ok`
+
+- <a href="#signature_verification_state_verify.error.err" name="signature_verification_state_verify.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_verification_state_close" name="signature_verification_state_close"></a> `signature_verification_state_close(state: signature_verification_state) -> crypto_errno`
+#### <a href="#signature_verification_state_close" name="signature_verification_state_close"></a> `signature_verification_state_close(state: signature_verification_state) -> Result<(), crypto_errno>`
 Destroy a signature verification state.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1420,12 +1729,21 @@ Note that closing a signature state doesn't close or invalidate the public key o
 - <a href="#signature_verification_state_close.state" name="signature_verification_state_close.state"></a> `state`: [`signature_verification_state`](#signature_verification_state)
 
 ##### Results
-- <a href="#signature_verification_state_close.error" name="signature_verification_state_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_verification_state_close.error" name="signature_verification_state_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_verification_state_close.error.ok" name="signature_verification_state_close.error.ok"></a> `ok`
+
+- <a href="#signature_verification_state_close.error.err" name="signature_verification_state_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#signature_close" name="signature_close"></a> `signature_close(signature: signature) -> crypto_errno`
+#### <a href="#signature_close" name="signature_close"></a> `signature_close(signature: signature) -> Result<(), crypto_errno>`
 Destroy a signature.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1434,7 +1752,16 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#signature_close.signature" name="signature_close.signature"></a> `signature`: [`signature`](#signature)
 
 ##### Results
-- <a href="#signature_close.error" name="signature_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#signature_close.error" name="signature_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#signature_close.error.ok" name="signature_close.error.ok"></a> `ok`
+
+- <a href="#signature_close.error.err" name="signature_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 ## <a href="#wasi_ephemeral_crypto_symmetric" name="wasi_ephemeral_crypto_symmetric"></a> wasi_ephemeral_crypto_symmetric
 ### Imports
@@ -1443,7 +1770,7 @@ Objects are reference counted. It is safe to close an object immediately after t
 
 ---
 
-#### <a href="#symmetric_key_generate" name="symmetric_key_generate"></a> `symmetric_key_generate(algorithm: string, options: opt_options) -> (crypto_errno, symmetric_key)`
+#### <a href="#symmetric_key_generate" name="symmetric_key_generate"></a> `symmetric_key_generate(algorithm: string, options: opt_options) -> Result<symmetric_key, crypto_errno>`
 Generate a new symmetric key for a given algorithm.
 
 [`options`](#options) can be `None` to use the default parameters, or an algoritm-specific set of parameters to override.
@@ -1456,14 +1783,21 @@ This function may return `unsupported_feature` if key generation is not supporte
 - <a href="#symmetric_key_generate.options" name="symmetric_key_generate.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#symmetric_key_generate.error" name="symmetric_key_generate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_generate.error" name="symmetric_key_generate.error"></a> `error`: `Result<symmetric_key, crypto_errno>`
 
-- <a href="#symmetric_key_generate.handle" name="symmetric_key_generate.handle"></a> `handle`: [`symmetric_key`](#symmetric_key)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_generate.error.ok" name="symmetric_key_generate.error.ok"></a> `ok`: [`symmetric_key`](#symmetric_key)
+
+- <a href="#symmetric_key_generate.error.err" name="symmetric_key_generate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_import" name="symmetric_key_import"></a> `symmetric_key_import(algorithm: string, raw: ConstPointer<u8>, raw_len: size) -> (crypto_errno, symmetric_key)`
+#### <a href="#symmetric_key_import" name="symmetric_key_import"></a> `symmetric_key_import(algorithm: string, raw: ConstPointer<u8>, raw_len: size) -> Result<symmetric_key, crypto_errno>`
 Create a symmetric key from raw material.
 
 The algorithm is internally stored along with the key, and trying to use the key with an operation expecting a different algorithm will return `invalid_key`.
@@ -1478,14 +1812,21 @@ The function may also return `unsupported_algorithm` if the algorithm is not sup
 - <a href="#symmetric_key_import.raw_len" name="symmetric_key_import.raw_len"></a> `raw_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_key_import.error" name="symmetric_key_import.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_import.error" name="symmetric_key_import.error"></a> `error`: `Result<symmetric_key, crypto_errno>`
 
-- <a href="#symmetric_key_import.handle" name="symmetric_key_import.handle"></a> `handle`: [`symmetric_key`](#symmetric_key)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_import.error.ok" name="symmetric_key_import.error.ok"></a> `ok`: [`symmetric_key`](#symmetric_key)
+
+- <a href="#symmetric_key_import.error.err" name="symmetric_key_import.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_export" name="symmetric_key_export"></a> `symmetric_key_export(symmetric_key: symmetric_key) -> (crypto_errno, array_output)`
+#### <a href="#symmetric_key_export" name="symmetric_key_export"></a> `symmetric_key_export(symmetric_key: symmetric_key) -> Result<array_output, crypto_errno>`
 Export a symmetric key as raw material.
 
 This is mainly useful to export a managed key.
@@ -1496,14 +1837,21 @@ May return `prohibited_operation` if this operation is denied.
 - <a href="#symmetric_key_export.symmetric_key" name="symmetric_key_export.symmetric_key"></a> `symmetric_key`: [`symmetric_key`](#symmetric_key)
 
 ##### Results
-- <a href="#symmetric_key_export.error" name="symmetric_key_export.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_export.error" name="symmetric_key_export.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#symmetric_key_export.encoded" name="symmetric_key_export.encoded"></a> `encoded`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_export.error.ok" name="symmetric_key_export.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#symmetric_key_export.error.err" name="symmetric_key_export.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_close" name="symmetric_key_close"></a> `symmetric_key_close(symmetric_key: symmetric_key) -> crypto_errno`
+#### <a href="#symmetric_key_close" name="symmetric_key_close"></a> `symmetric_key_close(symmetric_key: symmetric_key) -> Result<(), crypto_errno>`
 Destroy a symmetric key.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1512,12 +1860,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#symmetric_key_close.symmetric_key" name="symmetric_key_close.symmetric_key"></a> `symmetric_key`: [`symmetric_key`](#symmetric_key)
 
 ##### Results
-- <a href="#symmetric_key_close.error" name="symmetric_key_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_close.error" name="symmetric_key_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_close.error.ok" name="symmetric_key_close.error.ok"></a> `ok`
+
+- <a href="#symmetric_key_close.error.err" name="symmetric_key_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_generate_managed" name="symmetric_key_generate_managed"></a> `symmetric_key_generate_managed(secrets_manager: secrets_manager, algorithm: string, options: opt_options) -> (crypto_errno, symmetric_key)`
+#### <a href="#symmetric_key_generate_managed" name="symmetric_key_generate_managed"></a> `symmetric_key_generate_managed(secrets_manager: secrets_manager, algorithm: string, options: opt_options) -> Result<symmetric_key, crypto_errno>`
 __(optional)__
 Generate a new managed symmetric key.
 
@@ -1540,14 +1897,21 @@ This is also an optional import, meaning that the function may not even exist.
 - <a href="#symmetric_key_generate_managed.options" name="symmetric_key_generate_managed.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#symmetric_key_generate_managed.error" name="symmetric_key_generate_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_generate_managed.error" name="symmetric_key_generate_managed.error"></a> `error`: `Result<symmetric_key, crypto_errno>`
 
-- <a href="#symmetric_key_generate_managed.handle" name="symmetric_key_generate_managed.handle"></a> `handle`: [`symmetric_key`](#symmetric_key)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_generate_managed.error.ok" name="symmetric_key_generate_managed.error.ok"></a> `ok`: [`symmetric_key`](#symmetric_key)
+
+- <a href="#symmetric_key_generate_managed.error.err" name="symmetric_key_generate_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_store_managed" name="symmetric_key_store_managed"></a> `symmetric_key_store_managed(secrets_manager: secrets_manager, symmetric_key: symmetric_key, symmetric_key_id: Pointer<u8>, symmetric_key_id_max_len: size) -> crypto_errno`
+#### <a href="#symmetric_key_store_managed" name="symmetric_key_store_managed"></a> `symmetric_key_store_managed(secrets_manager: secrets_manager, symmetric_key: symmetric_key, symmetric_key_id: Pointer<u8>, symmetric_key_id_max_len: size) -> Result<(), crypto_errno>`
 __(optional)__
 Store a symmetric key into the secrets manager.
 
@@ -1566,12 +1930,21 @@ The function returns `overflow` if the supplied buffer is too small.
 - <a href="#symmetric_key_store_managed.symmetric_key_id_max_len" name="symmetric_key_store_managed.symmetric_key_id_max_len"></a> `symmetric_key_id_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_key_store_managed.error" name="symmetric_key_store_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_store_managed.error" name="symmetric_key_store_managed.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_store_managed.error.ok" name="symmetric_key_store_managed.error.ok"></a> `ok`
+
+- <a href="#symmetric_key_store_managed.error.err" name="symmetric_key_store_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_replace_managed" name="symmetric_key_replace_managed"></a> `symmetric_key_replace_managed(secrets_manager: secrets_manager, symmetric_key_old: symmetric_key, symmetric_key_new: symmetric_key) -> (crypto_errno, version)`
+#### <a href="#symmetric_key_replace_managed" name="symmetric_key_replace_managed"></a> `symmetric_key_replace_managed(secrets_manager: secrets_manager, symmetric_key_old: symmetric_key, symmetric_key_new: symmetric_key) -> Result<version, crypto_errno>`
 __(optional)__
 Replace a managed symmetric key.
 
@@ -1602,14 +1975,21 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#symmetric_key_replace_managed.symmetric_key_new" name="symmetric_key_replace_managed.symmetric_key_new"></a> `symmetric_key_new`: [`symmetric_key`](#symmetric_key)
 
 ##### Results
-- <a href="#symmetric_key_replace_managed.error" name="symmetric_key_replace_managed.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_replace_managed.error" name="symmetric_key_replace_managed.error"></a> `error`: `Result<version, crypto_errno>`
 
-- <a href="#symmetric_key_replace_managed.version" name="symmetric_key_replace_managed.version"></a> `version`: [`version`](#version)
+###### Variant Layout
+- size: 16
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_replace_managed.error.ok" name="symmetric_key_replace_managed.error.ok"></a> `ok`: [`version`](#version)
+
+- <a href="#symmetric_key_replace_managed.error.err" name="symmetric_key_replace_managed.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_id" name="symmetric_key_id"></a> `symmetric_key_id(symmetric_key: symmetric_key, symmetric_key_id: Pointer<u8>, symmetric_key_id_max_len: size) -> (crypto_errno, size, version)`
+#### <a href="#symmetric_key_id" name="symmetric_key_id"></a> `symmetric_key_id(symmetric_key: symmetric_key, symmetric_key_id: Pointer<u8>, symmetric_key_id_max_len: size) -> Result<(size, version), crypto_errno>`
 __(optional)__
 Return the key identifier and version of a managed symmetric key.
 
@@ -1625,16 +2005,30 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#symmetric_key_id.symmetric_key_id_max_len" name="symmetric_key_id.symmetric_key_id_max_len"></a> `symmetric_key_id_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_key_id.error" name="symmetric_key_id.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_id.error" name="symmetric_key_id.error"></a> `error`: `Result<(size, version), crypto_errno>`
 
-- <a href="#symmetric_key_id.symmetric_key_id_len" name="symmetric_key_id.symmetric_key_id_len"></a> `symmetric_key_id_len`: [`size`](#size)
+###### Variant Layout
+- size: 24
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_id.error.ok" name="symmetric_key_id.error.ok"></a> `ok`: `(size, version)`
 
-- <a href="#symmetric_key_id.version" name="symmetric_key_id.version"></a> `version`: [`version`](#version)
+####### Record members
+- <a href="#symmetric_key_id.error.ok.0" name="symmetric_key_id.error.ok.0"></a> `0`: [`size`](#size)
+
+Offset: 0
+
+- <a href="#symmetric_key_id.error.ok.1" name="symmetric_key_id.error.ok.1"></a> `1`: [`version`](#version)
+
+Offset: 8
+
+- <a href="#symmetric_key_id.error.err" name="symmetric_key_id.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_key_from_id" name="symmetric_key_from_id"></a> `symmetric_key_from_id(secrets_manager: secrets_manager, symmetric_key_id: ConstPointer<u8>, symmetric_key_id_len: size, symmetric_key_version: version) -> (crypto_errno, symmetric_key)`
+#### <a href="#symmetric_key_from_id" name="symmetric_key_from_id"></a> `symmetric_key_from_id(secrets_manager: secrets_manager, symmetric_key_id: ConstPointer<u8>, symmetric_key_id_len: size, symmetric_key_version: version) -> Result<symmetric_key, crypto_errno>`
 __(optional)__
 Return a managed symmetric key from a key identifier.
 
@@ -1654,14 +2048,21 @@ This is an optional import, meaning that the function may not even exist.
 - <a href="#symmetric_key_from_id.symmetric_key_version" name="symmetric_key_from_id.symmetric_key_version"></a> `symmetric_key_version`: [`version`](#version)
 
 ##### Results
-- <a href="#symmetric_key_from_id.error" name="symmetric_key_from_id.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_key_from_id.error" name="symmetric_key_from_id.error"></a> `error`: `Result<symmetric_key, crypto_errno>`
 
-- <a href="#symmetric_key_from_id.handle" name="symmetric_key_from_id.handle"></a> `handle`: [`symmetric_key`](#symmetric_key)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_key_from_id.error.ok" name="symmetric_key_from_id.error.ok"></a> `ok`: [`symmetric_key`](#symmetric_key)
+
+- <a href="#symmetric_key_from_id.error.err" name="symmetric_key_from_id.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_open" name="symmetric_state_open"></a> `symmetric_state_open(algorithm: string, key: opt_symmetric_key, options: opt_options) -> (crypto_errno, symmetric_state)`
+#### <a href="#symmetric_state_open" name="symmetric_state_open"></a> `symmetric_state_open(algorithm: string, key: opt_symmetric_key, options: opt_options) -> Result<symmetric_state, crypto_errno>`
 Create a new state to aborb and produce data using symmetric operations.
 
 The state remains valid after every operation in order to support incremental updates.
@@ -1847,14 +2248,21 @@ let next_key_handle = ctx.symmetric_state_squeeze_key(state_handle, "Xoodyak-128
 - <a href="#symmetric_state_open.options" name="symmetric_state_open.options"></a> `options`: [`opt_options`](#opt_options)
 
 ##### Results
-- <a href="#symmetric_state_open.error" name="symmetric_state_open.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_open.error" name="symmetric_state_open.error"></a> `error`: `Result<symmetric_state, crypto_errno>`
 
-- <a href="#symmetric_state_open.symmetric_state" name="symmetric_state_open.symmetric_state"></a> `symmetric_state`: [`symmetric_state`](#symmetric_state)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_open.error.ok" name="symmetric_state_open.error.ok"></a> `ok`: [`symmetric_state`](#symmetric_state)
+
+- <a href="#symmetric_state_open.error.err" name="symmetric_state_open.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_options_get" name="symmetric_state_options_get"></a> `symmetric_state_options_get(handle: symmetric_state, name: string, value: Pointer<u8>, value_max_len: size) -> (crypto_errno, size)`
+#### <a href="#symmetric_state_options_get" name="symmetric_state_options_get"></a> `symmetric_state_options_get(handle: symmetric_state, name: string, value: Pointer<u8>, value_max_len: size) -> Result<size, crypto_errno>`
 Retrieve a parameter from the current state.
 
 In particular, `symmetric_state_options_get("nonce")` can be used to get a nonce that as automatically generated.
@@ -1873,14 +2281,21 @@ It may also return `unsupported_option` if the option doesn't exist for the chos
 - <a href="#symmetric_state_options_get.value_max_len" name="symmetric_state_options_get.value_max_len"></a> `value_max_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_options_get.error" name="symmetric_state_options_get.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_options_get.error" name="symmetric_state_options_get.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_state_options_get.value_len" name="symmetric_state_options_get.value_len"></a> `value_len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_options_get.error.ok" name="symmetric_state_options_get.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_state_options_get.error.err" name="symmetric_state_options_get.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_options_get_u64" name="symmetric_state_options_get_u64"></a> `symmetric_state_options_get_u64(handle: symmetric_state, name: string) -> (crypto_errno, u64)`
+#### <a href="#symmetric_state_options_get_u64" name="symmetric_state_options_get_u64"></a> `symmetric_state_options_get_u64(handle: symmetric_state, name: string) -> Result<u64, crypto_errno>`
 Retrieve an integer parameter from the current state.
 
 In particular, `symmetric_state_options_get("nonce")` can be used to get a nonce that as automatically generated.
@@ -1895,14 +2310,21 @@ It may also return `unsupported_option` if the option doesn't exist for the chos
 - <a href="#symmetric_state_options_get_u64.name" name="symmetric_state_options_get_u64.name"></a> `name`: `string`
 
 ##### Results
-- <a href="#symmetric_state_options_get_u64.error" name="symmetric_state_options_get_u64.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_options_get_u64.error" name="symmetric_state_options_get_u64.error"></a> `error`: `Result<u64, crypto_errno>`
 
-- <a href="#symmetric_state_options_get_u64.value" name="symmetric_state_options_get_u64.value"></a> `value`: `u64`
+###### Variant Layout
+- size: 16
+- align: 8
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_options_get_u64.error.ok" name="symmetric_state_options_get_u64.error.ok"></a> `ok`: [`u64`](#u64)
+
+- <a href="#symmetric_state_options_get_u64.error.err" name="symmetric_state_options_get_u64.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_close" name="symmetric_state_close"></a> `symmetric_state_close(handle: symmetric_state) -> crypto_errno`
+#### <a href="#symmetric_state_close" name="symmetric_state_close"></a> `symmetric_state_close(handle: symmetric_state) -> Result<(), crypto_errno>`
 Destroy a symmetric state.
 
 Objects are reference counted. It is safe to close an object immediately after the last function needing it is called.
@@ -1911,12 +2333,21 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#symmetric_state_close.handle" name="symmetric_state_close.handle"></a> `handle`: [`symmetric_state`](#symmetric_state)
 
 ##### Results
-- <a href="#symmetric_state_close.error" name="symmetric_state_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_close.error" name="symmetric_state_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_close.error.ok" name="symmetric_state_close.error.ok"></a> `ok`
+
+- <a href="#symmetric_state_close.error.err" name="symmetric_state_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_absorb" name="symmetric_state_absorb"></a> `symmetric_state_absorb(handle: symmetric_state, data: ConstPointer<u8>, data_len: size) -> crypto_errno`
+#### <a href="#symmetric_state_absorb" name="symmetric_state_absorb"></a> `symmetric_state_absorb(handle: symmetric_state, data: ConstPointer<u8>, data_len: size) -> Result<(), crypto_errno>`
 Absorb data into the state.
 
 - **Hash functions:** adds data to be hashed.
@@ -1938,12 +2369,21 @@ If too much data has been fed for the algorithm, `overflow` may be thrown.
 - <a href="#symmetric_state_absorb.data_len" name="symmetric_state_absorb.data_len"></a> `data_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_absorb.error" name="symmetric_state_absorb.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_absorb.error" name="symmetric_state_absorb.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_absorb.error.ok" name="symmetric_state_absorb.error.ok"></a> `ok`
+
+- <a href="#symmetric_state_absorb.error.err" name="symmetric_state_absorb.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_squeeze" name="symmetric_state_squeeze"></a> `symmetric_state_squeeze(handle: symmetric_state, out: Pointer<u8>, out_len: size) -> crypto_errno`
+#### <a href="#symmetric_state_squeeze" name="symmetric_state_squeeze"></a> `symmetric_state_squeeze(handle: symmetric_state, out: Pointer<u8>, out_len: size) -> Result<(), crypto_errno>`
 Squeeze bytes from the state.
 
 - **Hash functions:** this tries to output an `out_len` bytes digest from the absorbed data. The hash function output will be truncated if necessary. If the requested size is too large, the `invalid_len` error code is returned.
@@ -1964,12 +2404,21 @@ In that case, the guest should retry with the same parameters until the function
 - <a href="#symmetric_state_squeeze.out_len" name="symmetric_state_squeeze.out_len"></a> `out_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_squeeze.error" name="symmetric_state_squeeze.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_squeeze.error" name="symmetric_state_squeeze.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_squeeze.error.ok" name="symmetric_state_squeeze.error.ok"></a> `ok`
+
+- <a href="#symmetric_state_squeeze.error.err" name="symmetric_state_squeeze.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_squeeze_tag" name="symmetric_state_squeeze_tag"></a> `symmetric_state_squeeze_tag(handle: symmetric_state) -> (crypto_errno, symmetric_tag)`
+#### <a href="#symmetric_state_squeeze_tag" name="symmetric_state_squeeze_tag"></a> `symmetric_state_squeeze_tag(handle: symmetric_state) -> Result<symmetric_tag, crypto_errno>`
 Compute and return a tag for all the data injected into the state so far.
 
 - **MAC functions**: returns a tag authenticating the absorbed data.
@@ -1985,14 +2434,21 @@ In that case, the guest should retry with the same parameters until the function
 - <a href="#symmetric_state_squeeze_tag.handle" name="symmetric_state_squeeze_tag.handle"></a> `handle`: [`symmetric_state`](#symmetric_state)
 
 ##### Results
-- <a href="#symmetric_state_squeeze_tag.error" name="symmetric_state_squeeze_tag.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_squeeze_tag.error" name="symmetric_state_squeeze_tag.error"></a> `error`: `Result<symmetric_tag, crypto_errno>`
 
-- <a href="#symmetric_state_squeeze_tag.symmetric_tag" name="symmetric_state_squeeze_tag.symmetric_tag"></a> `symmetric_tag`: [`symmetric_tag`](#symmetric_tag)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_squeeze_tag.error.ok" name="symmetric_state_squeeze_tag.error.ok"></a> `ok`: [`symmetric_tag`](#symmetric_tag)
+
+- <a href="#symmetric_state_squeeze_tag.error.err" name="symmetric_state_squeeze_tag.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_squeeze_key" name="symmetric_state_squeeze_key"></a> `symmetric_state_squeeze_key(handle: symmetric_state, alg_str: string) -> (crypto_errno, symmetric_key)`
+#### <a href="#symmetric_state_squeeze_key" name="symmetric_state_squeeze_key"></a> `symmetric_state_squeeze_key(handle: symmetric_state, alg_str: string) -> Result<symmetric_key, crypto_errno>`
 Use the current state to produce a key for a target algorithm.
 
 For extract-then-expand constructions, this returns the PRK.
@@ -2006,14 +2462,21 @@ For session-base authentication encryption, this returns a key that can be used 
 - <a href="#symmetric_state_squeeze_key.alg_str" name="symmetric_state_squeeze_key.alg_str"></a> `alg_str`: `string`
 
 ##### Results
-- <a href="#symmetric_state_squeeze_key.error" name="symmetric_state_squeeze_key.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_squeeze_key.error" name="symmetric_state_squeeze_key.error"></a> `error`: `Result<symmetric_key, crypto_errno>`
 
-- <a href="#symmetric_state_squeeze_key.symmetric_key" name="symmetric_state_squeeze_key.symmetric_key"></a> `symmetric_key`: [`symmetric_key`](#symmetric_key)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_squeeze_key.error.ok" name="symmetric_state_squeeze_key.error.ok"></a> `ok`: [`symmetric_key`](#symmetric_key)
+
+- <a href="#symmetric_state_squeeze_key.error.err" name="symmetric_state_squeeze_key.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_max_tag_len" name="symmetric_state_max_tag_len"></a> `symmetric_state_max_tag_len(handle: symmetric_state) -> (crypto_errno, size)`
+#### <a href="#symmetric_state_max_tag_len" name="symmetric_state_max_tag_len"></a> `symmetric_state_max_tag_len(handle: symmetric_state) -> Result<size, crypto_errno>`
 Return the maximum length of an authentication tag for the current algorithm.
 
 This allows guests to compute the size required to store a ciphertext along with its authentication tag.
@@ -2028,14 +2491,21 @@ For a decryption operation, the size of the buffer that will store the decrypted
 - <a href="#symmetric_state_max_tag_len.handle" name="symmetric_state_max_tag_len.handle"></a> `handle`: [`symmetric_state`](#symmetric_state)
 
 ##### Results
-- <a href="#symmetric_state_max_tag_len.error" name="symmetric_state_max_tag_len.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_max_tag_len.error" name="symmetric_state_max_tag_len.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_state_max_tag_len.len" name="symmetric_state_max_tag_len.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_max_tag_len.error.ok" name="symmetric_state_max_tag_len.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_state_max_tag_len.error.err" name="symmetric_state_max_tag_len.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_encrypt" name="symmetric_state_encrypt"></a> `symmetric_state_encrypt(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size) -> (crypto_errno, size)`
+#### <a href="#symmetric_state_encrypt" name="symmetric_state_encrypt"></a> `symmetric_state_encrypt(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size) -> Result<size, crypto_errno>`
 Encrypt data with an attached tag.
 
 - **Stream cipher:** adds the input to the stream cipher output. `out_len` and `data_len` can be equal, as no authentication tags will be added.
@@ -2060,14 +2530,21 @@ The function returns the actual size of the ciphertext along with the tag.
 - <a href="#symmetric_state_encrypt.data_len" name="symmetric_state_encrypt.data_len"></a> `data_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_encrypt.error" name="symmetric_state_encrypt.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_encrypt.error" name="symmetric_state_encrypt.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_state_encrypt.actual_out_len" name="symmetric_state_encrypt.actual_out_len"></a> `actual_out_len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_encrypt.error.ok" name="symmetric_state_encrypt.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_state_encrypt.error.err" name="symmetric_state_encrypt.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_encrypt_detached" name="symmetric_state_encrypt_detached"></a> `symmetric_state_encrypt_detached(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size) -> (crypto_errno, symmetric_tag)`
+#### <a href="#symmetric_state_encrypt_detached" name="symmetric_state_encrypt_detached"></a> `symmetric_state_encrypt_detached(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size) -> Result<symmetric_tag, crypto_errno>`
 Encrypt data, with a detached tag.
 
 - **Stream cipher:** returns `invalid_operation` since stream ciphers do not include authentication tags.
@@ -2092,14 +2569,21 @@ The function returns the tag.
 - <a href="#symmetric_state_encrypt_detached.data_len" name="symmetric_state_encrypt_detached.data_len"></a> `data_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_encrypt_detached.error" name="symmetric_state_encrypt_detached.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_encrypt_detached.error" name="symmetric_state_encrypt_detached.error"></a> `error`: `Result<symmetric_tag, crypto_errno>`
 
-- <a href="#symmetric_state_encrypt_detached.symmetric_tag" name="symmetric_state_encrypt_detached.symmetric_tag"></a> `symmetric_tag`: [`symmetric_tag`](#symmetric_tag)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_encrypt_detached.error.ok" name="symmetric_state_encrypt_detached.error.ok"></a> `ok`: [`symmetric_tag`](#symmetric_tag)
+
+- <a href="#symmetric_state_encrypt_detached.error.err" name="symmetric_state_encrypt_detached.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_decrypt" name="symmetric_state_decrypt"></a> `symmetric_state_decrypt(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size) -> (crypto_errno, size)`
+#### <a href="#symmetric_state_decrypt" name="symmetric_state_decrypt"></a> `symmetric_state_decrypt(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size) -> Result<size, crypto_errno>`
 - **Stream cipher:** adds the input to the stream cipher output. `out_len` and `data_len` can be equal, as no authentication tags will be added.
 - **AEAD:** decrypts `data` into `out`. Additional data must have been previously absorbed using `symmetric_state_absorb()`.
 - **SHOE, Xoodyak, Strobe:** decrypts data, squeezes a tag and verify that it matches the one that was appended to the ciphertext.
@@ -2126,14 +2610,21 @@ The function returns the actual size of the decrypted message, which can be smal
 - <a href="#symmetric_state_decrypt.data_len" name="symmetric_state_decrypt.data_len"></a> `data_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_decrypt.error" name="symmetric_state_decrypt.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_decrypt.error" name="symmetric_state_decrypt.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_state_decrypt.actual_out_len" name="symmetric_state_decrypt.actual_out_len"></a> `actual_out_len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_decrypt.error.ok" name="symmetric_state_decrypt.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_state_decrypt.error.err" name="symmetric_state_decrypt.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_decrypt_detached" name="symmetric_state_decrypt_detached"></a> `symmetric_state_decrypt_detached(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size, raw_tag: ConstPointer<u8>, raw_tag_len: size) -> (crypto_errno, size)`
+#### <a href="#symmetric_state_decrypt_detached" name="symmetric_state_decrypt_detached"></a> `symmetric_state_decrypt_detached(handle: symmetric_state, out: Pointer<u8>, out_len: size, data: ConstPointer<u8>, data_len: size, raw_tag: ConstPointer<u8>, raw_tag_len: size) -> Result<size, crypto_errno>`
 - **Stream cipher:** returns `invalid_operation` since stream ciphers do not include authentication tags.
 - **AEAD:** decrypts `data` into `out`. Additional data must have been previously absorbed using `symmetric_state_absorb()`.
 - **SHOE, Xoodyak, Strobe:** decrypts data, squeezes a tag and verify that it matches the expected one.
@@ -2165,14 +2656,21 @@ The function returns the actual size of the decrypted message.
 - <a href="#symmetric_state_decrypt_detached.raw_tag_len" name="symmetric_state_decrypt_detached.raw_tag_len"></a> `raw_tag_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_state_decrypt_detached.error" name="symmetric_state_decrypt_detached.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_decrypt_detached.error" name="symmetric_state_decrypt_detached.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_state_decrypt_detached.actual_out_len" name="symmetric_state_decrypt_detached.actual_out_len"></a> `actual_out_len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_decrypt_detached.error.ok" name="symmetric_state_decrypt_detached.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_state_decrypt_detached.error.err" name="symmetric_state_decrypt_detached.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_state_ratchet" name="symmetric_state_ratchet"></a> `symmetric_state_ratchet(handle: symmetric_state) -> crypto_errno`
+#### <a href="#symmetric_state_ratchet" name="symmetric_state_ratchet"></a> `symmetric_state_ratchet(handle: symmetric_state) -> Result<(), crypto_errno>`
 Make it impossible to recover the previous state.
 
 This operation is supported by some systems keeping a rolling state over an entire session, for forward security.
@@ -2183,12 +2681,21 @@ This operation is supported by some systems keeping a rolling state over an enti
 - <a href="#symmetric_state_ratchet.handle" name="symmetric_state_ratchet.handle"></a> `handle`: [`symmetric_state`](#symmetric_state)
 
 ##### Results
-- <a href="#symmetric_state_ratchet.error" name="symmetric_state_ratchet.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_state_ratchet.error" name="symmetric_state_ratchet.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_state_ratchet.error.ok" name="symmetric_state_ratchet.error.ok"></a> `ok`
+
+- <a href="#symmetric_state_ratchet.error.err" name="symmetric_state_ratchet.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_tag_len" name="symmetric_tag_len"></a> `symmetric_tag_len(symmetric_tag: symmetric_tag) -> (crypto_errno, size)`
+#### <a href="#symmetric_tag_len" name="symmetric_tag_len"></a> `symmetric_tag_len(symmetric_tag: symmetric_tag) -> Result<size, crypto_errno>`
 Return the length of an authentication tag.
 
 This function can be used by a guest to allocate the correct buffer size to copy a computed authentication tag.
@@ -2197,14 +2704,21 @@ This function can be used by a guest to allocate the correct buffer size to copy
 - <a href="#symmetric_tag_len.symmetric_tag" name="symmetric_tag_len.symmetric_tag"></a> `symmetric_tag`: [`symmetric_tag`](#symmetric_tag)
 
 ##### Results
-- <a href="#symmetric_tag_len.error" name="symmetric_tag_len.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_tag_len.error" name="symmetric_tag_len.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_tag_len.len" name="symmetric_tag_len.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_tag_len.error.ok" name="symmetric_tag_len.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_tag_len.error.err" name="symmetric_tag_len.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_tag_pull" name="symmetric_tag_pull"></a> `symmetric_tag_pull(symmetric_tag: symmetric_tag, buf: Pointer<u8>, buf_len: size) -> (crypto_errno, size)`
+#### <a href="#symmetric_tag_pull" name="symmetric_tag_pull"></a> `symmetric_tag_pull(symmetric_tag: symmetric_tag, buf: Pointer<u8>, buf_len: size) -> Result<size, crypto_errno>`
 Copy an authentication tag into a guest-allocated buffer.
 
 The handle automatically becomes invalid after this operation. Manually closing it is not required.
@@ -2228,14 +2742,21 @@ Otherwise, it returns the number of bytes that have been copied.
 - <a href="#symmetric_tag_pull.buf_len" name="symmetric_tag_pull.buf_len"></a> `buf_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_tag_pull.error" name="symmetric_tag_pull.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_tag_pull.error" name="symmetric_tag_pull.error"></a> `error`: `Result<size, crypto_errno>`
 
-- <a href="#symmetric_tag_pull.len" name="symmetric_tag_pull.len"></a> `len`: [`size`](#size)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_tag_pull.error.ok" name="symmetric_tag_pull.error.ok"></a> `ok`: [`size`](#size)
+
+- <a href="#symmetric_tag_pull.error.err" name="symmetric_tag_pull.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_tag_verify" name="symmetric_tag_verify"></a> `symmetric_tag_verify(symmetric_tag: symmetric_tag, expected_raw_tag_ptr: ConstPointer<u8>, expected_raw_tag_len: size) -> crypto_errno`
+#### <a href="#symmetric_tag_verify" name="symmetric_tag_verify"></a> `symmetric_tag_verify(symmetric_tag: symmetric_tag, expected_raw_tag_ptr: ConstPointer<u8>, expected_raw_tag_len: size) -> Result<(), crypto_errno>`
 Verify that a computed authentication tag matches the expected value, in constant-time.
 
 The expected tag must be provided as a raw byte string.
@@ -2260,12 +2781,21 @@ ctx.symmetric_tag_verify(computed_tag_handle, expected_raw_tag)?;
 - <a href="#symmetric_tag_verify.expected_raw_tag_len" name="symmetric_tag_verify.expected_raw_tag_len"></a> `expected_raw_tag_len`: [`size`](#size)
 
 ##### Results
-- <a href="#symmetric_tag_verify.error" name="symmetric_tag_verify.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_tag_verify.error" name="symmetric_tag_verify.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_tag_verify.error.ok" name="symmetric_tag_verify.error.ok"></a> `ok`
+
+- <a href="#symmetric_tag_verify.error.err" name="symmetric_tag_verify.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#symmetric_tag_close" name="symmetric_tag_close"></a> `symmetric_tag_close(symmetric_tag: symmetric_tag) -> crypto_errno`
+#### <a href="#symmetric_tag_close" name="symmetric_tag_close"></a> `symmetric_tag_close(symmetric_tag: symmetric_tag) -> Result<(), crypto_errno>`
 Explicitly destroy an unused authentication tag.
 
 This is usually not necessary, as `symmetric_tag_pull()` automatically closes a tag after it has been copied.
@@ -2276,7 +2806,16 @@ Objects are reference counted. It is safe to close an object immediately after t
 - <a href="#symmetric_tag_close.symmetric_tag" name="symmetric_tag_close.symmetric_tag"></a> `symmetric_tag`: [`symmetric_tag`](#symmetric_tag)
 
 ##### Results
-- <a href="#symmetric_tag_close.error" name="symmetric_tag_close.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#symmetric_tag_close.error" name="symmetric_tag_close.error"></a> `error`: `Result<(), crypto_errno>`
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#symmetric_tag_close.error.ok" name="symmetric_tag_close.error.ok"></a> `ok`
+
+- <a href="#symmetric_tag_close.error.err" name="symmetric_tag_close.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 ## <a href="#wasi_ephemeral_crypto_kx" name="wasi_ephemeral_crypto_kx"></a> wasi_ephemeral_crypto_kx
 ### Imports
@@ -2285,7 +2824,7 @@ Objects are reference counted. It is safe to close an object immediately after t
 
 ---
 
-#### <a href="#kx_dh" name="kx_dh"></a> `kx_dh(pk: publickey, sk: secretkey) -> (crypto_errno, array_output)`
+#### <a href="#kx_dh" name="kx_dh"></a> `kx_dh(pk: publickey, sk: secretkey) -> Result<array_output, crypto_errno>`
 Perform a simple Diffie-Hellman key exchange.
 
 Both keys must be of the same type, or else the `$crypto_errno.incompatible_keys` error is returned.
@@ -2299,14 +2838,21 @@ Otherwide, a raw shared key is returned, and can be imported as a symmetric key.
 - <a href="#kx_dh.sk" name="kx_dh.sk"></a> `sk`: [`secretkey`](#secretkey)
 
 ##### Results
-- <a href="#kx_dh.error" name="kx_dh.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#kx_dh.error" name="kx_dh.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#kx_dh.shared_secret" name="kx_dh.shared_secret"></a> `shared_secret`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#kx_dh.error.ok" name="kx_dh.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#kx_dh.error.err" name="kx_dh.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#kx_encapsulate" name="kx_encapsulate"></a> `kx_encapsulate(pk: publickey) -> (crypto_errno, array_output, array_output)`
+#### <a href="#kx_encapsulate" name="kx_encapsulate"></a> `kx_encapsulate(pk: publickey) -> Result<(array_output, array_output), crypto_errno>`
 Create a shared secret and encrypt it for the given public key.
 
 This operation is only compatible with specific algorithms.
@@ -2318,16 +2864,30 @@ On success, both the shared secret and its encrypted version are returned.
 - <a href="#kx_encapsulate.pk" name="kx_encapsulate.pk"></a> `pk`: [`publickey`](#publickey)
 
 ##### Results
-- <a href="#kx_encapsulate.error" name="kx_encapsulate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#kx_encapsulate.error" name="kx_encapsulate.error"></a> `error`: `Result<(array_output, array_output), crypto_errno>`
 
-- <a href="#kx_encapsulate.secret" name="kx_encapsulate.secret"></a> `secret`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 12
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#kx_encapsulate.error.ok" name="kx_encapsulate.error.ok"></a> `ok`: `(array_output, array_output)`
 
-- <a href="#kx_encapsulate.encapsulated_secret" name="kx_encapsulate.encapsulated_secret"></a> `encapsulated_secret`: [`array_output`](#array_output)
+####### Record members
+- <a href="#kx_encapsulate.error.ok.0" name="kx_encapsulate.error.ok.0"></a> `0`: [`array_output`](#array_output)
+
+Offset: 0
+
+- <a href="#kx_encapsulate.error.ok.1" name="kx_encapsulate.error.ok.1"></a> `1`: [`array_output`](#array_output)
+
+Offset: 4
+
+- <a href="#kx_encapsulate.error.err" name="kx_encapsulate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
 
 
 ---
 
-#### <a href="#kx_decapsulate" name="kx_decapsulate"></a> `kx_decapsulate(sk: secretkey, encapsulated_secret: ConstPointer<u8>, encapsulated_secret_len: size) -> (crypto_errno, array_output)`
+#### <a href="#kx_decapsulate" name="kx_decapsulate"></a> `kx_decapsulate(sk: secretkey, encapsulated_secret: ConstPointer<u8>, encapsulated_secret_len: size) -> Result<array_output, crypto_errno>`
 Decapsulate an encapsulated secret crated with [`kx_encapsulate`](#kx_encapsulate)
 
 Return the secret, or `$crypto_errno.verification_failed` on error.
@@ -2340,7 +2900,15 @@ Return the secret, or `$crypto_errno.verification_failed` on error.
 - <a href="#kx_decapsulate.encapsulated_secret_len" name="kx_decapsulate.encapsulated_secret_len"></a> `encapsulated_secret_len`: [`size`](#size)
 
 ##### Results
-- <a href="#kx_decapsulate.error" name="kx_decapsulate.error"></a> `error`: [`crypto_errno`](#crypto_errno)
+- <a href="#kx_decapsulate.error" name="kx_decapsulate.error"></a> `error`: `Result<array_output, crypto_errno>`
 
-- <a href="#kx_decapsulate.secret" name="kx_decapsulate.secret"></a> `secret`: [`array_output`](#array_output)
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#kx_decapsulate.error.ok" name="kx_decapsulate.error.ok"></a> `ok`: [`array_output`](#array_output)
+
+- <a href="#kx_decapsulate.error.err" name="kx_decapsulate.error.err"></a> `err`: [`crypto_errno`](#crypto_errno)
+
 


### PR DESCRIPTION
This is a preparatory PR to follow-up from WebAssembly/WASI#395

This commit merges the current WASI main branch into this repository and then adds a commit on top which updates the *.witx files to follow the new conventions, notably around type names and result types.

It's also worth noting that this probably shouldn't get merged until WebAssembly/WASI#395 is merged, at which point in time I'll rebase.