### PR TITLE
Some fix

### DIFF
--- a/docs/wasi-crypto.md
+++ b/docs/wasi-crypto.md
@@ -152,7 +152,7 @@ Applications never access these representations directly. Keys, group elements a
 * `pkcs8`: `PKCS#8`/`DER` encoding. Implementations MAY support encryption.
 * `pem`: `PEM`-encoded `PKCS#8`/`DER` format. Implementations MAY support encryption.
 * `sec`: Affine coordinates [`SEC-1`](https://www.secg.org/sec1-v2.pdf) elliptic curve point encoding.
-* `compressec_sec`: Single-coordinate [`SEC-1`](https://www.secg.org/sec1-v2.pdf) elliptic curve point encoding.
+* `compressed_sec`: Single-coordinate [`SEC-1`](https://www.secg.org/sec1-v2.pdf) elliptic curve point encoding.
 * `local`: implemented-defined encoding. Such a representation can be more efficient than standard serialization formats, but is not defined not required by the `wasi-crypto` specification, and is thus not meant to be portable across implementations.
 
 Encodings are specified as constants, which are defined for individual key types:
@@ -951,7 +951,7 @@ symmetric_state_absorb(state_handle, b"value 3")?;
 symmetric_state_squeeze(state_handle, &mut out)?;
 ```
 
-Individual inputs to the `absorb()` function MUST be domain separated and MUST NOT be concatenateed.
+Individual inputs to the `absorb()` function MUST be domain separated and MUST NOT be concatenated.
 
 ### Key derivation using extract-and-expand
 

--- a/implementations/hostcalls/rust/src/asymmetric_common/publickey.rs
+++ b/implementations/hostcalls/rust/src/asymmetric_common/publickey.rs
@@ -44,6 +44,7 @@ impl PublicKey {
                 encoded,
                 encoding,
             )?)),
+            AlgorithmType::KeyExchange => bail!(CryptoError::NotImplemented),
             _ => bail!(CryptoError::InvalidOperation),
         }
     }

--- a/implementations/hostcalls/rust/src/symmetric/chacha_poly.rs
+++ b/implementations/hostcalls/rust/src/symmetric/chacha_poly.rs
@@ -93,8 +93,7 @@ impl SymmetricKeyBuilder for ChaChaPolySymmetricKeyBuilder {
 
     fn key_len(&self) -> Result<usize, CryptoError> {
         match self.alg {
-            SymmetricAlgorithm::ChaCha20Poly1305 => Ok(16),
-            SymmetricAlgorithm::XChaCha20Poly1305 => Ok(32),
+            SymmetricAlgorithm::ChaCha20Poly1305 | SymmetricAlgorithm::XChaCha20Poly1305 => Ok(32),
             _ => bail!(CryptoError::UnsupportedAlgorithm),
         }
     }


### PR DESCRIPTION
Sorry, I am not familiar with cryptography and may be making some really stupid mistakes
4a0c70cd0c48a33549ce39f4b19946b24e83c236 include a doc type.
e179e8b351d04bfd568f5b0eb636610d56939a9a  Read your [answer](https://crypto.stackexchange.com/questions/73220/which-version-of-chacha-is-more-secure) that chachapoly20 key size always [256bits](https://doc.libsodium.org/secret-key_cryptography/aead)
dd6e41d4ab6cb671a679e0d73a7bf2d951aa2c98 Seem it should return NotImplemented instead of InvaildOperation. I'm not relly sure- I just read [proposal](https://github.com/WebAssembly/wasi-crypto/blob/main/docs/wasi-crypto.md#key-pairs) about this.
Wait for your review :) 
