### PR TITLE
Fix symmetric_state_options_get() examples

### DIFF
--- a/docs/wasi-crypto.md
+++ b/docs/wasi-crypto.md
@@ -297,7 +297,7 @@ Example usage (reading an option set by the runtime):
 ```rust
 let options_handle = options_open(AlgorithmType::Symmetric)?;
 let state_handle = symmetric_state_open("XChaCha20-Poly1305", None, Some(options_handle));
-let nonce_handle = symmetric_state_options_get(state_handle, "nonce")?; // array_output handle
+let nonce = symmetric_state_options_get(state_handle, "nonce")?;
 ```
 
 Three option types are supported and can be mixed and matched in an option set:
@@ -1082,8 +1082,7 @@ let mut nonce = [0u8; 24];
 
 let state_handle = symmetric_state_open("AES-256-GCM-SIV", Some(key_handle), None)?;
 
-let nonce_handle = symmetric_state_options_get(state_handle, "nonce")?;
-array_output_pull(nonce_handle, &mut nonce)?;
+let nonce = symmetric_state_options_get(state_handle, "nonce")?;
 
 let mut ciphertext = vec![0u8; message.len() + symmetric_state_max_tag_len(state_handle)?];
 symmetric_state_absorb(state_handle, "additional data")?;

--- a/witx/codegen/wasi_ephemeral_crypto.md
+++ b/witx/codegen/wasi_ephemeral_crypto.md
@@ -1464,8 +1464,7 @@ Returned error type: _[`crypto_errno`](#crypto_errno)_
 > 
 > let state_handle = ctx.symmetric_state_open("AES-256-GCM-SIV", Some(key_handle), None)?;
 > 
-> let nonce_handle = ctx.symmetric_state_options_get(state_handle, "nonce")?;
-> ctx.array_output_pull(nonce_handle, &mut nonce)?;
+> let nonce = ctx.symmetric_state_options_get(state_handle, "nonce")?;
 > 
 > let mut ciphertext = vec![0u8; message.len() + ctx.symmetric_state_max_tag_len(state_handle)?];
 > ctx.symmetric_state_absorb(state_handle, "additional data")?;
@@ -1532,8 +1531,6 @@ Returned error type: _[`crypto_errno`](#crypto_errno)_
 * _[`u64`](#u64)_ mutable pointer
 
 > Retrieve an integer parameter from the current state.
-> 
-> In particular, `symmetric_state_options_get("nonce")` can be used to get a nonce that as automatically generated.
 > 
 > The function may return `options_not_set` if an option was not set.
 > 

--- a/witx/codegen/wasi_ephemeral_crypto_symmetric.md
+++ b/witx/codegen/wasi_ephemeral_crypto_symmetric.md
@@ -741,8 +741,7 @@ Returned error type: _[`crypto_errno`](#crypto_errno)_
 > 
 > let state_handle = ctx.symmetric_state_open("AES-256-GCM-SIV", Some(key_handle), None)?;
 > 
-> let nonce_handle = ctx.symmetric_state_options_get(state_handle, "nonce")?;
-> ctx.array_output_pull(nonce_handle, &mut nonce)?;
+> let nonce = ctx.symmetric_state_options_get(state_handle, "nonce")?;
 > 
 > let mut ciphertext = vec![0u8; message.len() + ctx.symmetric_state_max_tag_len(state_handle)?];
 > ctx.symmetric_state_absorb(state_handle, "additional data")?;
@@ -809,8 +808,6 @@ Returned error type: _[`crypto_errno`](#crypto_errno)_
 * _[`u64`](#u64)_ mutable pointer
 
 > Retrieve an integer parameter from the current state.
-> 
-> In particular, `symmetric_state_options_get("nonce")` can be used to get a nonce that as automatically generated.
 > 
 > The function may return `options_not_set` if an option was not set.
 > 

--- a/witx/codegen/wasi_ephemeral_crypto_symmetric.witx
+++ b/witx/codegen/wasi_ephemeral_crypto_symmetric.witx
@@ -284,8 +284,7 @@
     ;;;
     ;;; let state_handle = ctx.symmetric_state_open("AES-256-GCM-SIV", Some(key_handle), None)?;
     ;;;
-    ;;; let nonce_handle = ctx.symmetric_state_options_get(state_handle, "nonce")?;
-    ;;; ctx.array_output_pull(nonce_handle, &mut nonce)?;
+    ;;; let nonce = ctx.symmetric_state_options_get(state_handle, "nonce")?;
     ;;;
     ;;; let mut ciphertext = vec![0u8; message.len() + ctx.symmetric_state_max_tag_len(state_handle)?];
     ;;; ctx.symmetric_state_absorb(state_handle, "additional data")?;
@@ -334,8 +333,6 @@
     )
 
     ;;; Retrieve an integer parameter from the current state.
-    ;;;
-    ;;; In particular, `symmetric_state_options_get("nonce")` can be used to get a nonce that as automatically generated.
     ;;;
     ;;; The function may return `options_not_set` if an option was not set.
     ;;;

--- a/witx/proposal_symmetric.witx
+++ b/witx/proposal_symmetric.witx
@@ -288,8 +288,7 @@
   ;;;
   ;;; let state_handle = ctx.symmetric_state_open("AES-256-GCM-SIV", Some(key_handle), None)?;
   ;;;
-  ;;; let nonce_handle = ctx.symmetric_state_options_get(state_handle, "nonce")?;
-  ;;; ctx.array_output_pull(nonce_handle, &mut nonce)?;
+  ;;; let nonce = ctx.symmetric_state_options_get(state_handle, "nonce")?;
   ;;;
   ;;; let mut ciphertext = vec![0u8; message.len() + ctx.symmetric_state_max_tag_len(state_handle)?];
   ;;; ctx.symmetric_state_absorb(state_handle, "additional data")?;
@@ -338,8 +337,6 @@
   )
 
   ;;; Retrieve an integer parameter from the current state.
-  ;;;
-  ;;; In particular, `symmetric_state_options_get("nonce")` can be used to get a nonce that as automatically generated.
   ;;;
   ;;; The function may return `options_not_set` if an option was not set.
   ;;;


### PR DESCRIPTION
The functions returns the value directly instead of a handle.

Fixes #46

/cc @sonder-joker 