### PR TITLE
Replace `parking_lot` with `std::sync::Mutex`.

### DIFF
--- a/implementations/hostcalls/rust/Cargo.toml
+++ b/implementations/hostcalls/rust/Cargo.toml
@@ -35,7 +35,6 @@ p256 = { version = "0.9", features = [
     "pkcs8",
     "pem",
 ] }
-parking_lot = "0.12"
 pqcrypto = { version = "0.14.0", default-features = false, features = [
     "pqcrypto-kyber",
 ], optional = true }

--- a/implementations/hostcalls/rust/src/handles.rs
+++ b/implementations/hostcalls/rust/src/handles.rs
@@ -1,5 +1,5 @@
-use parking_lot::Mutex;
 use std::collections::HashMap;
+use std::sync::Mutex;
 
 use crate::error::*;
 
@@ -23,15 +23,15 @@ impl<HandleType: Clone + Send + Sync> HandlesManager<HandleType> {
     }
 
     pub fn close(&self, handle: Handle) -> Result<(), CryptoError> {
-        self.inner.lock().close(handle)
+        self.inner.lock().unwrap().close(handle)
     }
 
     pub fn register(&self, op: HandleType) -> Result<Handle, CryptoError> {
-        self.inner.lock().register(op)
+        self.inner.lock().unwrap().register(op)
     }
 
     pub fn get(&self, handle: Handle) -> Result<HandleType, CryptoError> {
-        self.inner.lock().get(handle).map(|x| x.clone())
+        self.inner.lock().unwrap().get(handle).map(|x| x.clone())
     }
 }
 

--- a/implementations/hostcalls/rust/src/key_exchange/keypair.rs
+++ b/implementations/hostcalls/rust/src/key_exchange/keypair.rs
@@ -1,8 +1,7 @@
 use super::*;
 
 use crate::asymmetric_common::*;
-use parking_lot::{Mutex, MutexGuard};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 #[derive(Clone)]
 pub struct KxKeyPair {
@@ -21,7 +20,7 @@ impl KxKeyPair {
     }
 
     pub fn inner(&self) -> MutexGuard<'_, Box<dyn KxKeyPairLike>> {
-        self.inner.lock()
+        self.inner.lock().unwrap()
     }
 
     pub fn locked<T, U>(&self, mut f: T) -> U

--- a/implementations/hostcalls/rust/src/key_exchange/mod.rs
+++ b/implementations/hostcalls/rust/src/key_exchange/mod.rs
@@ -13,8 +13,7 @@ use crate::array_output::*;
 use crate::error::*;
 use crate::handles::*;
 use crate::options::*;
-use parking_lot::Mutex;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 pub use keypair::*;
 pub use publickey::*;

--- a/implementations/hostcalls/rust/src/key_exchange/publickey.rs
+++ b/implementations/hostcalls/rust/src/key_exchange/publickey.rs
@@ -1,8 +1,7 @@
 use super::*;
 use crate::asymmetric_common::*;
 use crate::CryptoCtx;
-use parking_lot::{Mutex, MutexGuard};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 pub trait KxPublicKeyBuilder {
     fn from_raw(&self, raw: &[u8]) -> Result<KxPublicKey, CryptoError>;
@@ -21,7 +20,7 @@ impl KxPublicKey {
     }
 
     pub fn inner(&self) -> MutexGuard<'_, Box<dyn KxPublicKeyLike>> {
-        self.inner.lock()
+        self.inner.lock().unwrap()
     }
 
     pub fn locked<T, U>(&self, mut f: T) -> U

--- a/implementations/hostcalls/rust/src/key_exchange/secretkey.rs
+++ b/implementations/hostcalls/rust/src/key_exchange/secretkey.rs
@@ -1,8 +1,7 @@
 use super::*;
 use crate::asymmetric_common::*;
 use crate::CryptoCtx;
-use parking_lot::{Mutex, MutexGuard};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 pub trait KxSecretKeyBuilder {
     fn from_raw(&self, raw: &[u8]) -> Result<KxSecretKey, CryptoError>;
@@ -21,7 +20,7 @@ impl KxSecretKey {
     }
 
     pub fn inner(&self) -> MutexGuard<'_, Box<dyn KxSecretKeyLike>> {
-        self.inner.lock()
+        self.inner.lock().unwrap()
     }
 
     pub fn locked<T, U>(&self, mut f: T) -> U

--- a/implementations/hostcalls/rust/src/signatures/signature.rs
+++ b/implementations/hostcalls/rust/src/signatures/signature.rs
@@ -1,6 +1,5 @@
-use parking_lot::{Mutex, MutexGuard};
 use std::convert::TryFrom;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 use subtle::ConstantTimeEq;
 
 use super::ecdsa::*;
@@ -54,7 +53,7 @@ impl Signature {
     }
 
     pub fn inner(&self) -> MutexGuard<'_, Box<dyn SignatureLike>> {
-        self.inner.lock()
+        self.inner.lock().unwrap()
     }
 
     pub fn locked<T, U>(&self, mut f: T) -> U
@@ -83,7 +82,7 @@ impl SignatureState {
     }
 
     fn inner(&self) -> MutexGuard<'_, Box<dyn SignatureStateLike>> {
-        self.inner.lock()
+        self.inner.lock().unwrap()
     }
 
     fn locked<T, U>(&self, mut f: T) -> U
@@ -133,7 +132,7 @@ impl SignatureVerificationState {
     }
 
     fn inner(&self) -> MutexGuard<'_, Box<dyn SignatureVerificationStateLike>> {
-        self.inner.lock()
+        self.inner.lock().unwrap()
     }
 
     fn locked<T, U>(&self, mut f: T) -> U

--- a/implementations/hostcalls/rust/src/symmetric/aes_gcm.rs
+++ b/implementations/hostcalls/rust/src/symmetric/aes_gcm.rs
@@ -114,7 +114,7 @@ impl AesGcmSymmetricState {
             .downcast_ref::<AesGcmSymmetricKey>()
             .ok_or(CryptoError::InvalidKey)?;
         let options = options.as_ref().ok_or(CryptoError::NonceRequired)?;
-        let inner = options.inner.lock();
+        let inner = options.inner.lock().unwrap();
         let nonce_vec = inner.nonce.as_ref().ok_or(CryptoError::NonceRequired)?;
         ensure!(nonce_vec.len() == NONCE_LEN, CryptoError::InvalidNonce);
         let mut nonce = [0u8; NONCE_LEN];

--- a/implementations/hostcalls/rust/src/symmetric/key.rs
+++ b/implementations/hostcalls/rust/src/symmetric/key.rs
@@ -3,8 +3,7 @@ use crate::array_output::*;
 use crate::version::*;
 use crate::CryptoCtx;
 
-use parking_lot::{Mutex, MutexGuard};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 #[derive(Clone)]
 pub struct SymmetricKey {
@@ -27,7 +26,7 @@ impl SymmetricKey {
     }
 
     pub fn inner(&self) -> MutexGuard<'_, Box<dyn SymmetricKeyLike>> {
-        self.inner.lock()
+        self.inner.lock().unwrap()
     }
 
     pub fn locked<T, U>(&self, mut f: T) -> U

--- a/implementations/hostcalls/rust/src/symmetric/mod.rs
+++ b/implementations/hostcalls/rust/src/symmetric/mod.rs
@@ -19,10 +19,9 @@ use self::xoodyak::*;
 use crate::error::*;
 use crate::handles::*;
 use crate::options::*;
-use parking_lot::{Mutex, MutexGuard};
 use std::any::Any;
 use std::convert::TryFrom;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 pub use self::key::SymmetricKey;
 pub use self::state::SymmetricState;
@@ -54,7 +53,7 @@ impl Default for SymmetricOptions {
 
 impl SymmetricOptions {
     fn inner(&self) -> MutexGuard<'_, SymmetricOptionsInner> {
-        self.inner.lock()
+        self.inner.lock().unwrap()
     }
 
     fn locked<T, U>(&self, mut f: T) -> U
@@ -75,7 +74,7 @@ impl OptionsLike for SymmetricOptions {
         name: &str,
         guest_buffer: &'static mut [u8],
     ) -> Result<(), CryptoError> {
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.lock().unwrap();
         let option = match name.to_lowercase().as_str() {
             "buffer" => &mut inner.guest_buffer,
             _ => bail!(CryptoError::UnsupportedOption),
@@ -85,7 +84,7 @@ impl OptionsLike for SymmetricOptions {
     }
 
     fn set(&mut self, name: &str, value: &[u8]) -> Result<(), CryptoError> {
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.lock().unwrap();
         let option = match name.to_lowercase().as_str() {
             "context" => &mut inner.context,
             "salt" => &mut inner.salt,
@@ -97,7 +96,7 @@ impl OptionsLike for SymmetricOptions {
     }
 
     fn get(&self, name: &str) -> Result<Vec<u8>, CryptoError> {
-        let inner = self.inner.lock();
+        let inner = self.inner.lock().unwrap();
         let value = match name.to_lowercase().as_str() {
             "context" => &inner.context,
             "salt" => &inner.salt,
@@ -108,7 +107,7 @@ impl OptionsLike for SymmetricOptions {
     }
 
     fn set_u64(&mut self, name: &str, value: u64) -> Result<(), CryptoError> {
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.lock().unwrap();
         let option = match name.to_lowercase().as_str() {
             "memory_limit" => &mut inner.memory_limit,
             "ops_limit" => &mut inner.ops_limit,
@@ -120,7 +119,7 @@ impl OptionsLike for SymmetricOptions {
     }
 
     fn get_u64(&self, name: &str) -> Result<u64, CryptoError> {
-        let inner = self.inner.lock();
+        let inner = self.inner.lock().unwrap();
         let value = match name.to_lowercase().as_str() {
             "memory_limit" => &inner.memory_limit,
             "ops_limit" => &inner.ops_limit,

--- a/implementations/hostcalls/rust/src/symmetric/state.rs
+++ b/implementations/hostcalls/rust/src/symmetric/state.rs
@@ -1,9 +1,8 @@
 use super::*;
 use crate::CryptoCtx;
 
-use parking_lot::{Mutex, MutexGuard};
 use std::convert::TryFrom;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 #[derive(Clone)]
 pub struct SymmetricState {
@@ -18,7 +17,7 @@ impl SymmetricState {
     }
 
     fn inner(&self) -> MutexGuard<'_, Box<dyn SymmetricStateLike>> {
-        self.inner.lock()
+        self.inner.lock().unwrap()
     }
 
     fn locked<T, U>(&self, mut f: T) -> U

--- a/implementations/hostcalls/rust/src/symmetric/xoodyak.rs
+++ b/implementations/hostcalls/rust/src/symmetric/xoodyak.rs
@@ -106,7 +106,7 @@ impl XoodyakSymmetricState {
         };
         let nonce = options
             .as_ref()
-            .and_then(|options| options.inner.lock().nonce.as_ref().cloned());
+            .and_then(|options| options.inner.lock().unwrap().nonce.as_ref().cloned());
         let nonce = nonce.as_deref();
         let xoodyak_state = match key {
             None => XoodyakAny::Hash(XoodyakHash::new()),


### PR DESCRIPTION
As of [Rust 1.62], `std::sync::Mutex` is much faster and doesn't require
dynamic allocation.

Also, it supports poisoning (see the added `.unwrap()` calls), which
means that if one thread panics while holding a locked mutex, other threads
trying to unlock the mutex will also panic, rather than silently
acquiring the lock. This gives applications a better chance of safely
shutting down in the event of a panic.

[Rust 1.62]: https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html