### PR TITLE
feat: support ECDSA_P384_SHA384

### DIFF
--- a/implementations/hostcalls/rust/Cargo.toml
+++ b/implementations/hostcalls/rust/Cargo.toml
@@ -34,6 +34,12 @@ p256 = { version = "0.11.1", features = [
     "pkcs8",
     "pem",
 ] }
+p384 = { version = "0.11.1", features = [
+    "ecdsa",
+    "std",
+    "pkcs8",
+    "pem",
+] }
 pqcrypto = { version = "0.15.0", default-features = false, features = [
     "pqcrypto-kyber",
 ], optional = true }

--- a/implementations/hostcalls/rust/src/signatures/mod.rs
+++ b/implementations/hostcalls/rust/src/signatures/mod.rs
@@ -22,6 +22,7 @@ use std::convert::TryFrom;
 pub enum SignatureAlgorithm {
     ECDSA_P256_SHA256,
     ECDSA_K256_SHA256,
+    ECDSA_P384_SHA384,
     Ed25519,
     RSA_PKCS1_2048_SHA256,
     RSA_PKCS1_2048_SHA384,
@@ -46,7 +47,7 @@ pub enum SignatureAlgorithmFamily {
 impl SignatureAlgorithm {
     pub fn family(&self) -> SignatureAlgorithmFamily {
         match self {
-            SignatureAlgorithm::ECDSA_P256_SHA256 | SignatureAlgorithm::ECDSA_K256_SHA256 => {
+            SignatureAlgorithm::ECDSA_P256_SHA256 | SignatureAlgorithm::ECDSA_K256_SHA256 | SignatureAlgorithm::ECDSA_P384_SHA384 => {
                 SignatureAlgorithmFamily::ECDSA
             }
             SignatureAlgorithm::Ed25519 => SignatureAlgorithmFamily::EdDSA,
@@ -73,6 +74,7 @@ impl TryFrom<&str> for SignatureAlgorithm {
         match alg_str.to_uppercase().as_str() {
             "ECDSA_P256_SHA256" => Ok(SignatureAlgorithm::ECDSA_P256_SHA256),
             "ECDSA_K256_SHA256" => Ok(SignatureAlgorithm::ECDSA_K256_SHA256),
+            "ECDSA_P384_SHA384" => Ok(SignatureAlgorithm::ECDSA_P384_SHA384),
 
             "ED25519" => Ok(SignatureAlgorithm::Ed25519),
 


### PR DESCRIPTION
Added `P384`, tested with https://github.com/rjzak/wasi-crypto-example.

Follow-up from:
* https://github.com/WebAssembly/wasi-crypto/pull/61
* https://github.com/WebAssembly/wasi-crypto/pull/62

@npmccallum @jedisct1

Signed-off-by: Richard Zak <richard@profian.com>