### PR TITLE
Remove constant related to point compression

### DIFF
--- a/implementations/bindings/assemblyscript/assembly/asymmetric_common.ts
+++ b/implementations/bindings/assemblyscript/assembly/asymmetric_common.ts
@@ -31,10 +31,6 @@ export class PublicKey {
         return this.encode_as(crypto.PublickeyEncoding.SEC);
     }
 
-    compressedSec(): ArrayBuffer | null {
-        return this.encode_as(crypto.PublickeyEncoding.COMPRESSED_SEC);
-    }
-
     local(): ArrayBuffer | null {
         return this.encode_as(crypto.PublickeyEncoding.LOCAL);
     }
@@ -61,10 +57,6 @@ export class PublicKey {
 
     protected static _fromSec(algType: crypto.AlgorithmType, alg: string, encoded: ArrayBuffer): PublicKey | null {
         return this.decode_from(algType, alg, encoded, crypto.PublickeyEncoding.SEC);
-    }
-
-    protected static _fromCompressedSec(algType: crypto.AlgorithmType, alg: string, encoded: ArrayBuffer): PublicKey | null {
-        return this.decode_from(algType, alg, encoded, crypto.PublickeyEncoding.COMPRESSED_SEC);
     }
 
     protected static _fromLocal(algType: crypto.AlgorithmType, alg: string, encoded: ArrayBuffer): PublicKey | null {

--- a/implementations/bindings/assemblyscript/assembly/signatures.ts
+++ b/implementations/bindings/assemblyscript/assembly/signatures.ts
@@ -71,10 +71,6 @@ export class SignaturePublicKey extends PublicKey {
         return changetype<SignaturePublicKey | null>(super._fromSec(crypto.AlgorithmType.SIGNATURES, alg, encoded));
     }
 
-    static fromCompressedSec(alg: string, encoded: ArrayBuffer): SignaturePublicKey | null {
-        return changetype<SignaturePublicKey | null>(super._fromCompressedSec(crypto.AlgorithmType.SIGNATURES, alg, encoded));
-    }
-
     static fromLocal(alg: string, encoded: ArrayBuffer): SignaturePublicKey | null {
         return changetype<SignaturePublicKey | null>(super._fromLocal(crypto.AlgorithmType.SIGNATURES, alg, encoded));
     }

--- a/implementations/bindings/assemblyscript/assembly/wasi_crypto.ts
+++ b/implementations/bindings/assemblyscript/assembly/wasi_crypto.ts
@@ -108,9 +108,7 @@ export namespace KeypairEncoding {
     export const RAW: KeypairEncoding = 0;
     export const PKCS_8: KeypairEncoding = 1;
     export const PEM: KeypairEncoding = 2;
-    export const COMPRESSED_PKCS_8: KeypairEncoding = 3;
-    export const COMPRESSED_PEM: KeypairEncoding = 4;
-    export const LOCAL: KeypairEncoding = 5;
+    export const LOCAL: KeypairEncoding = 3;
 }
 
 /**
@@ -123,10 +121,7 @@ export namespace PublickeyEncoding {
     export const PKCS_8: PublickeyEncoding = 1;
     export const PEM: PublickeyEncoding = 2;
     export const SEC: PublickeyEncoding = 3;
-    export const COMPRESSED_SEC: PublickeyEncoding = 4;
-    export const COMPRESSED_PKCS_8: PublickeyEncoding = 5;
-    export const COMPRESSED_PEM: PublickeyEncoding = 6;
-    export const LOCAL: PublickeyEncoding = 7;
+    export const LOCAL: PublickeyEncoding = 4;
 }
 
 /**

--- a/implementations/bindings/rust/src/asymmetric_common/keypair.rs
+++ b/implementations/bindings/rust/src/asymmetric_common/keypair.rs
@@ -67,14 +67,6 @@ impl KeyPair {
         Self::decode_from(alg_type, alg, encoded, raw::KEYPAIR_ENCODING_PEM)
     }
 
-    pub fn from_compressed_pem(
-        alg_type: raw::AlgorithmType,
-        alg: &'static str,
-        encoded: impl AsRef<[u8]>,
-    ) -> Result<Self, Error> {
-        Self::decode_from(alg_type, alg, encoded, raw::KEYPAIR_ENCODING_COMPRESSED_PEM)
-    }
-
     pub fn from_local(
         alg_type: raw::AlgorithmType,
         alg: &'static str,

--- a/implementations/bindings/rust/src/asymmetric_common/publickey.rs
+++ b/implementations/bindings/rust/src/asymmetric_common/publickey.rs
@@ -52,38 +52,12 @@ impl PublicKey {
         Self::decode_from(alg_type, alg, encoded, raw::PUBLICKEY_ENCODING_PEM)
     }
 
-    pub fn from_compressed_pem(
-        alg_type: raw::AlgorithmType,
-        alg: &'static str,
-        encoded: impl AsRef<[u8]>,
-    ) -> Result<Self, Error> {
-        Self::decode_from(
-            alg_type,
-            alg,
-            encoded,
-            raw::PUBLICKEY_ENCODING_COMPRESSED_PEM,
-        )
-    }
-
     pub fn from_sec(
         alg_type: raw::AlgorithmType,
         alg: &'static str,
         encoded: impl AsRef<[u8]>,
     ) -> Result<Self, Error> {
         Self::decode_from(alg_type, alg, encoded, raw::PUBLICKEY_ENCODING_SEC)
-    }
-
-    pub fn from_compressed_sec(
-        alg_type: raw::AlgorithmType,
-        alg: &'static str,
-        encoded: impl AsRef<[u8]>,
-    ) -> Result<Self, Error> {
-        Self::decode_from(
-            alg_type,
-            alg,
-            encoded,
-            raw::PUBLICKEY_ENCODING_COMPRESSED_SEC,
-        )
     }
 
     pub fn from_local(

--- a/implementations/bindings/rust/src/signatures/low/key_pair.rs
+++ b/implementations/bindings/rust/src/signatures/low/key_pair.rs
@@ -43,17 +43,6 @@ impl SignatureKeyPair {
         )?))
     }
 
-    pub fn from_compressed_pem(
-        alg: &'static str,
-        encoded: impl AsRef<[u8]>,
-    ) -> Result<Self, Error> {
-        Ok(SignatureKeyPair(KeyPair::from_compressed_pem(
-            raw::ALGORITHM_TYPE_SIGNATURES,
-            alg,
-            encoded,
-        )?))
-    }
-
     pub fn from_local(alg: &'static str, encoded: impl AsRef<[u8]>) -> Result<Self, Error> {
         Ok(SignatureKeyPair(KeyPair::from_local(
             raw::ALGORITHM_TYPE_SIGNATURES,

--- a/implementations/bindings/rust/src/signatures/low/public_key.rs
+++ b/implementations/bindings/rust/src/signatures/low/public_key.rs
@@ -31,30 +31,8 @@ impl SignaturePublicKey {
         )?))
     }
 
-    pub fn from_compressed_pem(
-        alg: &'static str,
-        encoded: impl AsRef<[u8]>,
-    ) -> Result<Self, Error> {
-        Ok(SignaturePublicKey(PublicKey::from_compressed_pem(
-            raw::ALGORITHM_TYPE_SIGNATURES,
-            alg,
-            encoded,
-        )?))
-    }
-
     pub fn from_sec(alg: &'static str, encoded: impl AsRef<[u8]>) -> Result<Self, Error> {
         Ok(SignaturePublicKey(PublicKey::from_sec(
-            raw::ALGORITHM_TYPE_SIGNATURES,
-            alg,
-            encoded,
-        )?))
-    }
-
-    pub fn from_compressed_sec(
-        alg: &'static str,
-        encoded: impl AsRef<[u8]>,
-    ) -> Result<Self, Error> {
-        Ok(SignaturePublicKey(PublicKey::from_compressed_sec(
             raw::ALGORITHM_TYPE_SIGNATURES,
             alg,
             encoded,

--- a/implementations/hostcalls/rust/src/asymmetric_common/publickey.rs
+++ b/implementations/hostcalls/rust/src/asymmetric_common/publickey.rs
@@ -7,7 +7,6 @@ pub enum PublicKeyEncoding {
     Pkcs8,
     Pem,
     Sec,
-    CompressedSec,
     Local,
 }
 

--- a/implementations/hostcalls/rust/src/asymmetric_common/secretkey.rs
+++ b/implementations/hostcalls/rust/src/asymmetric_common/secretkey.rs
@@ -8,7 +8,6 @@ pub enum SecretKeyEncoding {
     Pkcs8,
     Pem,
     Sec,
-    CompressedSec,
     Local,
 }
 

--- a/implementations/hostcalls/rust/src/signatures/ecdsa.rs
+++ b/implementations/hostcalls/rust/src/signatures/ecdsa.rs
@@ -480,9 +480,7 @@ impl EcdsaSignaturePublicKey {
     ) -> Result<Self, CryptoError> {
         match encoding {
             PublicKeyEncoding::Raw => Self::from_raw(alg, encoded),
-            PublicKeyEncoding::Sec | PublicKeyEncoding::CompressedSec => {
-                Self::from_sec(alg, encoded)
-            }
+            PublicKeyEncoding::Sec => Self::from_sec(alg, encoded),
             PublicKeyEncoding::Pkcs8 => Self::from_pkcs8(alg, encoded),
             PublicKeyEncoding::Pem => Self::from_pem(alg, encoded),
             _ => bail!(CryptoError::UnsupportedEncoding),
@@ -493,7 +491,6 @@ impl EcdsaSignaturePublicKey {
         match encoding {
             PublicKeyEncoding::Raw => self.as_raw(),
             PublicKeyEncoding::Sec => self.as_sec(false),
-            PublicKeyEncoding::CompressedSec => self.as_sec(true),
             _ => bail!(CryptoError::UnsupportedEncoding),
         }
     }

--- a/witx/codegen/wasi_ephemeral_crypto.md
+++ b/witx/codegen/wasi_ephemeral_crypto.md
@@ -61,8 +61,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`raw`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pem`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pem`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`local`**: _[`keypair_encoding`](#keypair_encoding)_
 
 > Encoding to use for importing or exporting a key pair.
@@ -78,9 +76,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`local`**: _[`publickey_encoding`](#publickey_encoding)_
 
 > Encoding to use for importing or exporting a public key.

--- a/witx/codegen/wasi_ephemeral_crypto.txt
+++ b/witx/codegen/wasi_ephemeral_crypto.txt
@@ -40,19 +40,14 @@ enum keypair_encoding: (tag: u16)
     - raw: 0
     - pkcs8: 1
     - pem: 2
-    - compressed_pkcs8: 3
-    - compressed_pem: 4
-    - local: 5
+    - local: 3
 
 enum publickey_encoding: (tag: u16)
     - raw: 0
     - pkcs8: 1
     - pem: 2
     - sec: 3
-    - compressed_sec: 4
-    - compressed_pkcs8: 5
-    - compressed_pem: 6
-    - local: 7
+    - local: 4
 
 enum secretkey_encoding: (tag: u16)
     - raw: 0

--- a/witx/codegen/wasi_ephemeral_crypto_asymmetric_common.md
+++ b/witx/codegen/wasi_ephemeral_crypto_asymmetric_common.md
@@ -61,8 +61,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`raw`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pem`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pem`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`local`**: _[`keypair_encoding`](#keypair_encoding)_
 
 > Encoding to use for importing or exporting a key pair.
@@ -78,9 +76,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`local`**: _[`publickey_encoding`](#publickey_encoding)_
 
 > Encoding to use for importing or exporting a public key.

--- a/witx/codegen/wasi_ephemeral_crypto_common.md
+++ b/witx/codegen/wasi_ephemeral_crypto_common.md
@@ -61,8 +61,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`raw`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pem`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pem`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`local`**: _[`keypair_encoding`](#keypair_encoding)_
 
 > Encoding to use for importing or exporting a key pair.
@@ -78,9 +76,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`local`**: _[`publickey_encoding`](#publickey_encoding)_
 
 > Encoding to use for importing or exporting a public key.

--- a/witx/codegen/wasi_ephemeral_crypto_common.witx
+++ b/witx/codegen/wasi_ephemeral_crypto_common.witx
@@ -160,12 +160,6 @@
             ;;; PEM encoding.
             $pem
 
-            ;;; PCSK8/DER encoding with compressed coordinates.
-            $compressed_pkcs8
-
-            ;;; PEM encoding with compressed coordinates.
-            $compressed_pem
-
             ;;; Implementation-defined encoding.
             $local
         )
@@ -185,15 +179,6 @@
 
             ;;; SEC-1 encoding.
             $sec
-
-            ;;; Compressed SEC-1 encoding.
-            $compressed_sec
-
-            ;;; PKCS8/DER encoding with compressed coordinates.
-            $compressed_pkcs8
-
-            ;;; PEM encoding with compressed coordinates.
-            $compressed_pem
 
             ;;; Implementation-defined encoding.
             $local

--- a/witx/codegen/wasi_ephemeral_crypto_external_secrets.md
+++ b/witx/codegen/wasi_ephemeral_crypto_external_secrets.md
@@ -61,8 +61,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`raw`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pem`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pem`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`local`**: _[`keypair_encoding`](#keypair_encoding)_
 
 > Encoding to use for importing or exporting a key pair.
@@ -78,9 +76,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`local`**: _[`publickey_encoding`](#publickey_encoding)_
 
 > Encoding to use for importing or exporting a public key.

--- a/witx/codegen/wasi_ephemeral_crypto_kx.md
+++ b/witx/codegen/wasi_ephemeral_crypto_kx.md
@@ -61,8 +61,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`raw`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pem`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pem`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`local`**: _[`keypair_encoding`](#keypair_encoding)_
 
 > Encoding to use for importing or exporting a key pair.
@@ -78,9 +76,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`local`**: _[`publickey_encoding`](#publickey_encoding)_
 
 > Encoding to use for importing or exporting a public key.

--- a/witx/codegen/wasi_ephemeral_crypto_signatures.md
+++ b/witx/codegen/wasi_ephemeral_crypto_signatures.md
@@ -61,8 +61,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`raw`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pem`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pem`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`local`**: _[`keypair_encoding`](#keypair_encoding)_
 
 > Encoding to use for importing or exporting a key pair.
@@ -78,9 +76,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`local`**: _[`publickey_encoding`](#publickey_encoding)_
 
 > Encoding to use for importing or exporting a public key.

--- a/witx/codegen/wasi_ephemeral_crypto_symmetric.md
+++ b/witx/codegen/wasi_ephemeral_crypto_symmetric.md
@@ -61,8 +61,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`raw`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`pem`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pkcs8`**: _[`keypair_encoding`](#keypair_encoding)_
-* **`compressed_pem`**: _[`keypair_encoding`](#keypair_encoding)_
 * **`local`**: _[`keypair_encoding`](#keypair_encoding)_
 
 > Encoding to use for importing or exporting a key pair.
@@ -78,9 +76,6 @@ Enumeration with tag type: `u16`, and the following members:
 * **`pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_sec`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pkcs8`**: _[`publickey_encoding`](#publickey_encoding)_
-* **`compressed_pem`**: _[`publickey_encoding`](#publickey_encoding)_
 * **`local`**: _[`publickey_encoding`](#publickey_encoding)_
 
 > Encoding to use for importing or exporting a public key.

--- a/witx/proposal_common.witx
+++ b/witx/proposal_common.witx
@@ -159,12 +159,6 @@
         ;;; PEM encoding.
         $pem
 
-        ;;; PCSK8/DER encoding with compressed coordinates.
-        $compressed_pkcs8
-
-        ;;; PEM encoding with compressed coordinates.
-        $compressed_pem
-
         ;;; Implementation-defined encoding.
         $local
     )
@@ -184,15 +178,6 @@
 
         ;;; SEC-1 encoding.
         $sec
-
-        ;;; Compressed SEC-1 encoding.
-        $compressed_sec
-
-        ;;; PKCS8/DER encoding with compressed coordinates.
-        $compressed_pkcs8
-
-        ;;; PEM encoding with compressed coordinates.
-        $compressed_pem
 
         ;;; Implementation-defined encoding.
         $local


### PR DESCRIPTION
This is a breaking change.

We still need to document the default format for every key type, as well as how to get from an uncompressed representation to a compressed one.

Fixes #55
