### PR TITLE
feat: Cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+resolver = "2"
+members = [
+    "implementations/bindings/rust",
+    "implementations/hostcalls/rust"
+]

--- a/implementations/bindings/rust/.cargo/config
+++ b/implementations/bindings/rust/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/implementations/bindings/rust/Cargo.toml
+++ b/implementations/bindings/rust/Cargo.toml
@@ -1,11 +1,12 @@
+cargo-features = ["per-package-target"]
+
 [package]
 name = "wasi-crypto-guest"
 version = "0.1.1"
 authors = ["Frank Denis <github@pureftpd.org>"]
 edition = "2018"
 publish = false
+forced-target = "wasm32-wasi"
 
 [dependencies]
 num_enum = "0.5"
-
-[workspace]

--- a/implementations/bindings/rust/rust-toolchain.toml
+++ b/implementations/bindings/rust/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+targets = ["wasm32-wasi"]
+profile = "minimal"


### PR DESCRIPTION
Use Cargo workspaces, plus other conveniences.
* Allows for some IDEs to properly analyze the source files
* Allows for projects to access the crates from Git instead of waiting for published versions on crates.io.

Signed-off-by: Richard Zak <richard@profian.com>