### PR TITLE
rust client bindings: fix the bound on num_enum

### DIFF
--- a/implementations/bindings/rust/Cargo.toml
+++ b/implementations/bindings/rust/Cargo.toml
@@ -8,4 +8,4 @@ description = "Example WASI-Crypto guest bindings for Rust"
 license-file = "LICENSE"
 
 [dependencies]
-num_enum = "0.5.7"
+num_enum = "=0.5.7"


### PR DESCRIPTION
The bound is currently `"0.5.7"` which allows version `0.5.8` to be selected, as
it's compatible in terms of semver. However, this version introduces a build
error in wasi-crypto, so we need to restrict to exactly `0.5.7`.

Here's an example build failure in wasmtime:
https://github.com/bytecodealliance/wasmtime/actions/runs/3880277713/jobs/6618200924
